### PR TITLE
Switch to new kernel testing system (still Ubuntu only), add security.ubuntu.com

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO list
+
+1. Add some "browse by date" links for /home/ftp/build-results/pxfuse-*.
+2. Investigate adding support for mirroring Ubuntu repository https://bugs.launchpad.net/~canonical-kernel-team/+archive/ubuntu/ppa
+3. Investigate linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/ ~canonical-kernel-team/+archive/ubuntu/ppa/+build/9593535

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+( cd portworx-kernel-tester && ./install.sh ) &&
+( cd portworx-mirror-server && ./install.sh )

--- a/portworx-kernel-tester/distro_driver.sh
+++ b/portworx-kernel-tester/distro_driver.sh
@@ -75,7 +75,7 @@ test_kernel_pkgs_func_loggable() {
     echo "test_kernel_pkgs_func_default: build_exit_code=$result" >&2
     if [ "$result" = 0 ] ; then
 	in_container tar -C "${container_tmpdir}/pxfuse_dir" -c px.ko |
-	    tar -C "${results_log_dir}" -xpv
+	    tar -C "${result_logdir}" -xpv
     fi
     uninstall_pkgs $(pkg_files_to_names "$@")
     echo "$result" > "${result_logdir}/exit_code"

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -42,3 +42,6 @@ old_crontab=$( ( crontab -u root -l 2> /dev/null ) |
 ( echo "$old_crontab" ;
   echo "15 1 * * * $scriptsdir/pwx_test_kernels.cron_script.sh" ) |
     crontab -u root -
+
+rm -f /var/www/html/build-results
+ln -s ${build_results_dir} /var/www/html/build-results

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -2,7 +2,8 @@
 
 prefix=/usr/local
 scriptsdir=${prefix}/share/portworx-kernel-tester/scripts
-build_results_dir=/var/lib/portworx-kernel-tester/build-results
+#build_results_dir=/var/lib/portworx-kernel-tester/build-results
+build_results_dir=/home/ftp/build-results
 bindir=${prefix}/bin
 
 set -e

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -19,6 +19,8 @@ install_scripts() {
     done
 }
 
+mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}"
+
 install_scripts "${scriptsdir}" \
 		container_driver.*.sh \
 		container_driver.sh \

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -25,7 +25,8 @@ install_scripts "${scriptsdir}" \
 		container_driver.*.sh \
 		container_driver.sh \
 		distro_driver.*.sh \
-		distro_driver.sh
+		distro_driver.sh \
+		pwx_test_kernels.cron_script.sh
 
 install_scripts "${bindir}" \
 		pwx_test_kernel_pkgs.sh \

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -34,3 +34,7 @@ install_scripts "${bindir}" \
 
 chmod a+x "${bindir}/pwx_test_kernel_pkgs.sh" "${bindir}/pwx_test_kernels_in_mirror.sh"
 
+old_crontab=$(crontab -u root -l | egrep -v pwx_test_kernels.cron_script.sh | egrep -v '^#' )
+( echo "$old_crontab" ;
+  echo "15 1 * * * $scriptsdir/pwx_test_kernels.cron_script.sh" ) |
+    crontab -u root -

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -32,9 +32,13 @@ install_scripts "${bindir}" \
 		pwx_test_kernel_pkgs.sh \
 		pwx_test_kernels_in_mirror.sh
 
-chmod a+x "${bindir}/pwx_test_kernel_pkgs.sh" "${bindir}/pwx_test_kernels_in_mirror.sh"
+chmod a+x "${bindir}/pwx_test_kernel_pkgs.sh" \
+      "${bindir}/pwx_test_kernels_in_mirror.sh" \
+      "${scriptsdir}/pwx_test_kernels.cron_script.sh"
 
-old_crontab=$(crontab -u root -l | egrep -v pwx_test_kernels.cron_script.sh | egrep -v '^#' )
+old_crontab=$( ( crontab -u root -l 2> /dev/null ) |
+	      egrep -v pwx_test_kernels.cron_script.sh |
+	      egrep -v '^#' ) || true
 ( echo "$old_crontab" ;
   echo "15 1 * * * $scriptsdir/pwx_test_kernels.cron_script.sh" ) |
     crontab -u root -

--- a/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
+++ b/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+logdir=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
+
+exec > "$logdir" 2>&1
+
+#for distribution in centos debian ubuntu ; do
+for dist in ubuntu ; do
+    pwx_test_kernels_in_mirror.sh --containers=lxc --distribution="$dist"
+done

--- a/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
+++ b/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
@@ -36,9 +36,10 @@ container_system=docker
 logdir="$build_results_dir"
 pxfuse_dir=""
 command=pwx_test_kernel_pkgs.sh
+mirror_top=/home/ftp/mirrors
 # Global variables set later:
 #   log_subdir
-mirror_top=
+
 
 while [[ $# -gt 0 ]] ; do
     case "$1" in

--- a/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
+++ b/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
@@ -7,7 +7,7 @@ build_results_dir=$PWD/build-results
 usage() {
     echo "Usage: test_kernels_in_mirror.sh [--distribution=dist] "
     echo "       [--containers=container_system] [--logdir=dir] "
-    echo "       [ --pxfuse=pxfuse_src_directory ] [ mirror_urls... ]"
+    echo "       [ --pxfuse=pxfuse_src_directory ] [ mirror_dirs... ]"
     echo ""
     echo "If pxfuse_src_directory is not specified, it is downloaded from"
     echo "github into a temporary directory."

--- a/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
+++ b/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
@@ -56,7 +56,7 @@ if [ $# = 0 ] ; then
     case "$distro" in
 	centos ) set /home/ftp/mirrors/http/elrepo.org/linux/kernel ;;
 	debian ) set /home/ftp/mirrors/http/snapshot.debian.org/archive/debian ;;
-	ubuntu ) set /home/ftp/mirrors/http/kernel.ubuntu.com/~kernel-ppa/mainline  ;;
+	ubuntu ) set /home/ftp/mirrors/http/kernel.ubuntu.com/~kernel-ppa/mainline /home/ftp/mirrors/http/security.ubuntu.com/ubuntu/pool/main/l/linux/" ;;
 	* ) echo "Unable to choose default mirror directory for unknown distribution \"$distro\"." >&2 ; exit 1 ;;
     esac
 fi

--- a/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
+++ b/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
@@ -56,7 +56,7 @@ if [ $# = 0 ] ; then
     case "$distro" in
 	centos ) set /home/ftp/mirrors/http/elrepo.org/linux/kernel ;;
 	debian ) set /home/ftp/mirrors/http/snapshot.debian.org/archive/debian ;;
-	ubuntu ) set /home/ftp/mirrors/http/kernel.ubuntu.com/~kernel-ppa/mainline /home/ftp/mirrors/http/security.ubuntu.com/ubuntu/pool/main/l/linux/" ;;
+	ubuntu ) set /home/ftp/mirrors/http/kernel.ubuntu.com/~kernel-ppa/mainline /home/ftp/mirrors/http/security.ubuntu.com/ubuntu/pool/main/l/linux/ ;;
 	* ) echo "Unable to choose default mirror directory for unknown distribution \"$distro\"." >&2 ; exit 1 ;;
     esac
 fi

--- a/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
+++ b/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
@@ -5,7 +5,9 @@ scriptsdir=$PWD
 build_results_dir=$PWD/build-results
 
 usage() {
-    echo "Usage: test_kernels_in_mirror.sh [--distribution=dist] [--containers=container_system] [--logdir=dir] [ --pxfuse=pxfuse_src_directory ] mirror_dir"
+    echo "Usage: test_kernels_in_mirror.sh [--distribution=dist] "
+    echo "       [--containers=container_system] [--logdir=dir] "
+    echo "       [ --pxfuse=pxfuse_src_directory ] [ mirror_urls... ]"
     echo ""
     echo "If pxfuse_src_directory is not specified, it is downloaded from"
     echo "github into a temporary directory."

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -41,7 +41,7 @@ install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_
 	adduser --system pwxmirror
 	crontab -u pwxmirror ${scriptsdir}/crontab.txt
 	( . ${scriptsdir}/pwx-mirror-config.sh && \
-	  mkdir -p $$mirrordir && chown -R pwxmirror $$mirrordir )
+	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/ubuntu && for subdir in centos debian ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )
 
 install_mirror: install_mirror_scripts install_mirror_ubuntu
 

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -46,7 +46,6 @@ run_all_test_scripts()
     #
     # run_all_verb_scripts test
     true
-    
 }
 
 mkdir -p "$logdir"

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -5,18 +5,20 @@ scriptsdir=$PWD
 logdir=${scriptsdir}/logs
 logfile=${logdir}/$(date +%Y%m%d.%H:%M:%S).log
 
-update_web_mirrors()
+copy_link_tree_remove_index_html()
 {
+    local from="$1"
+    local to="$2"
+
     set +e
-    symlinks -d "${web_mirrordir}"
+    symlinks -d "${to}"
 
-    cp --symbolic-link --recursive --remove-destination \
-       "${mirrordir}/." "${web_mirrordir}"
+    cp --symbolic-link --recursive --remove-destination "$from/." "$to"
 
-    find "${web_mirrordir}" -name index.html -print0 | xargs --null -- rm -f
-    find "${web_mirrordir}" -type d | sort -r | xargs rmdir 2> /dev/null || true
+    find "$to" -name index.html -print0 | xargs --null -- rm -f
+    find "$to" -type d | sort -r | xargs rmdir 2> /dev/null || true
 
-    symlinks -cs "${web_mirrordir}"
+    symlinks -cs "$to"
 }
 
 run_all_verb_scripts()
@@ -31,7 +33,8 @@ run_all_verb_scripts()
 run_all_mirror_scripts()
 {
     run_all_verb_scripts mirror
-    update_web_mirrors
+    copy_link_tree_remove_index_html "${mirrordir}" "${web_mirrordir}"
+    copy_link_tree_remove_index_html "${ftp_top}/build-results" "${web_top}/build-results"
 }
 
 run_all_test_scripts()

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -34,7 +34,7 @@ run_all_mirror_scripts()
 {
     run_all_verb_scripts mirror
     copy_link_tree_remove_index_html "${mirrordir}" "${web_mirrordir}"
-    copy_link_tree_remove_index_html "${ftp_top}/build-results" "${web_top}/build-results"
+    # copy_link_tree_remove_index_html "${ftp_top}/build-results" "${web_top}/build-results"
 }
 
 run_all_test_scripts()

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -39,7 +39,14 @@ run_all_mirror_scripts()
 
 run_all_test_scripts()
 {
-    run_all_verb_scripts test
+    # For now, disable this, because the new test scripts need to run
+    # as root to run lxc commands.  This should be fixable as LXC does
+    # have some support for running containers by a non-superuser
+    # (via lxd?).
+    #
+    # run_all_verb_scripts test
+    true
+    
 }
 
 mkdir -p "$logdir"

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -63,11 +63,10 @@ url_to_dir()
 }
 
 mirror_one_dir() {
-    local url="$1"
-    wget ${TIMESTAMPING} --protocol-directories --force-directories \
+     wget ${TIMESTAMPING} --protocol-directories --force-directories \
 	 --recursive --level=1 \
 	 --accept-regex=".*/index.html|(linux-headers-${above_3_9_regexp}.*(${arch}|all)\.deb)\$" \
-	 "$url"
+	 "$@"
 }
 
 mirror_subdirs() {

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -8,13 +8,13 @@ cd ${mirrordir} || exit $?
 mirrordir=/home/ftp/mirrors
 
 
-top_url=http://kernel.ubuntu.com/~kernel-ppa/mainline
-
 #arch=i386
 arch=amd64
 
 #TIMESTAMPING=--timestamping
 TIMESTAMPING=--no-clobber
+
+above_3_9_regexp='(3\.[1-9][0-9]|[4-9]|[1-9][0-9])'
 
 newlines_around_angle_brackets() {
     sed 's/</\'$'\n''</g;s/>/>\'$'\n''/g;'
@@ -27,7 +27,7 @@ extract_subdirs() {
 }
 
 versions_above_3_9 () {
-    egrep '^v(4|3\.[1-9][0-9]).*/$'
+    egrep "^v${above_3_9_regexp}.*/\$"
 }
 
 subdirs_to_urls() {
@@ -62,6 +62,11 @@ url_to_dir()
     echo "$prefix/$suffix"
 }
 
+mirror_one_dir() {
+    local url="$1"
+    wget ${TIMESTAMPING} --protocol-directories --force-directories --mirror --level=1 --accept-regexp=".*/index.html|/|linux-headers-${above_3_9_regexp}.*(${arch}|all)\.deb" "$url"
+}
+
 mirror_subdirs() {
     local top_url="$1"
     local top_dir
@@ -86,4 +91,5 @@ mirror_subdirs() {
 	xargs -- wget ${TIMESTAMPING} --protocol-directories --force-directories
 }
 
-mirror_subdirs "$top_url"
+mirror_one_dir "http://security.ubuntu.com/ ubuntu/pool/main/l/linux/"
+mirror_subdirs "http://kernel.ubuntu.com/~kernel-ppa/mainline"

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -8,9 +8,7 @@ cd ${mirrordir} || exit $?
 mirrordir=/home/ftp/mirrors
 
 
-url_dir=kernel.ubuntu.com/~kernel-ppa/mainline
-top_url=http://$url_dir
-top_dir=http/$url_dir
+top_url=http://kernel.ubuntu.com/~kernel-ppa/mainline
 
 #arch=i386
 arch=amd64
@@ -56,21 +54,36 @@ get_subdir_index_files() {
 	      --accept=index.html --recursive
 }
 
-rm -f ${top_dir}/index.html
-wget --force-directories --protocol-directories ${top_url}/
+url_to_dir()
+{
+    local url="$1"
+    local prefix="${url%%://*}"
+    local suffix="${url#:*//}"
+    echo "$prefix/$suffix"
+}
 
-# FIXME.  This breaks for subdirectory names containing spaces.
-subdirs=$(extract_subdirs <  ${top_dir}/index.html | versions_above_3_9)
+mirror_subdirs() {
+    local top_url="$1"
+    local top_dir
+    top_dir=$(url_to_dir "$top_url")
+    rm -f ${top_dir}/index.html
+    wget --force-directories --protocol-directories ${top_url}/
 
-get_subdir_index_files "$top_url"
+    # FIXME.  This breaks for subdirectory names containing spaces.
+    subdirs=$(extract_subdirs <  ${top_dir}/index.html | versions_above_3_9)
 
-# TODO: Change "image" to "headers"
-for subdir in $subdirs ; do
-    #which=image
-    which=headers
-    subdir_no_slash=${subdir%/}
-    extract_subdirs < "${top_dir}/$subdir/index.html" |
-	egrep "linux-${which}-[0-9].*_(${arch}|all).deb" |
-	subdirs_to_urls "${top_url}/${subdir_no_slash}"
-done |
-    xargs -- wget ${TIMESTAMPING} --protocol-directories --force-directories
+    get_subdir_index_files "$top_url"
+
+    # TODO: Change "image" to "headers"
+    for subdir in $subdirs ; do
+	#which=image
+	which=headers
+	subdir_no_slash=${subdir%/}
+	extract_subdirs < "${top_dir}/$subdir/index.html" |
+	    egrep "linux-${which}-[0-9].*_(${arch}|all).deb" |
+	    subdirs_to_urls "${top_url}/${subdir_no_slash}"
+    done |
+	xargs -- wget ${TIMESTAMPING} --protocol-directories --force-directories
+}
+
+mirror_subdirs "$top_url"

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -64,7 +64,10 @@ url_to_dir()
 
 mirror_one_dir() {
     local url="$1"
-    wget ${TIMESTAMPING} --protocol-directories --force-directories --mirror --level=1 --accept-regexp=".*/index.html|/|linux-headers-${above_3_9_regexp}.*(${arch}|all)\.deb" "$url"
+    wget ${TIMESTAMPING} --protocol-directories --force-directories \
+	 --recursive --level=1 \
+	 --accept-regex=".*/index.html|(linux-headers-${above_3_9_regexp}.*(${arch}|all)\.deb)\$" \
+	 "$url"
 }
 
 mirror_subdirs() {

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -110,5 +110,5 @@ mirror_subdirs() {
 
 mirror_one_dir "http://security.ubuntu.com/ubuntu/pool/main/l/linux/"
 mirror_subdirs "http://kernel.ubuntu.com/~kernel-ppa/mainline"
-# TODO?: mirror https://bugs.launchpad.net/~ canonical-kernel-team/+ archive/ubuntu/ppa
-# TODO?: Investigate  linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/ ~canonical-kernel-team/+ archive/ubuntu/ppa/+build/ 9593535
+# TODO?: mirror https://bugs.launchpad.net/~canonical-kernel-team/+archive/ubuntu/ppa
+# TODO?: Investigate linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/~canonical-kernel-team/+archive/ubuntu/ppa/+build/9593535

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -49,9 +49,8 @@ get_subdir_index_files() {
     local top_url="$1"
     echo_one_per_line $subdirs |
         subdirs_to_urls "${top_url}"  |
-        xargs -- wget ${TIMESTAMPING} \
-	      --protocol-directories --force-directories \
-	      --accept=index.html --recursive
+        xargs -- wget ${TIMESTAMPING} --quiet --protocol-directories \
+	      --force-directories --accept=index.html --recursive
 }
 
 url_to_dir()
@@ -78,7 +77,7 @@ mirror_one_dir() {
 	remove_index_html_mirror_files "$@"
     fi
 
-    wget ${TIMESTAMPING} --protocol-directories --force-directories \
+    wget ${TIMESTAMPING} --quiet --protocol-directories --force-directories \
 	 --recursive --level=1 \
 	 --accept-regex=".*/index.html|(linux-headers-${above_3_9_regexp}.*(${arch}|all)\.deb)\$" \
 	 "$@"
@@ -89,7 +88,7 @@ mirror_subdirs() {
     local top_dir
     top_dir=$(url_to_dir "$top_url")
     rm -f ${top_dir}/index.html
-    wget --force-directories --protocol-directories ${top_url}/
+    wget --quiet --force-directories --protocol-directories ${top_url}/
 
     # FIXME.  This breaks for subdirectory names containing spaces.
     subdirs=$(extract_subdirs <  ${top_dir}/index.html | versions_above_3_9)
@@ -105,7 +104,8 @@ mirror_subdirs() {
 	    egrep "linux-${which}-[0-9].*_(${arch}|all).deb" |
 	    subdirs_to_urls "${top_url}/${subdir_no_slash}"
     done |
-	xargs -- wget ${TIMESTAMPING} --protocol-directories --force-directories
+	xargs -- wget ${TIMESTAMPING} --quiet \
+	      --protocol-directories --force-directories
 }
 
 mirror_one_dir "http://security.ubuntu.com/ubuntu/pool/main/l/linux/"

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -93,3 +93,5 @@ mirror_subdirs() {
 
 mirror_one_dir "http://security.ubuntu.com/ ubuntu/pool/main/l/linux/"
 mirror_subdirs "http://kernel.ubuntu.com/~kernel-ppa/mainline"
+# TODO?: mirror https://bugs.launchpad.net/~ canonical-kernel-team/+ archive/ubuntu/ppa
+# TODO?: Investigate  linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/ ~canonical-kernel-team/+ archive/ubuntu/ppa/+build/ 9593535

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -57,7 +57,7 @@ url_to_dir()
 {
     local url="$1"
     local prefix="${url%%://*}"
-    local suffix="${url#:*//}"
+    local suffix="${url#*://}"
     echo "$prefix/$suffix"
 }
 

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -51,6 +51,7 @@ echo_one_per_line() {
 }
 
 get_subdir_index_files() {
+    local top_url="$1"
     echo_one_per_line $subdirs |
         subdirs_to_urls "${top_url}"  |
         xargs -- wget ${TIMESTAMPING} \
@@ -61,7 +62,7 @@ get_subdir_index_files() {
 # FIXME.  This breaks for subdirectory names containing spaces.
 subdirs=$(extract_subdirs <  ${top_dir}/index.html | versions_above_3_9)
 
-get_subdir_index_files
+get_subdir_index_files "$top_url"
 
 # TODO: Change "image" to "headers"
 for subdir in $subdirs ; do

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -91,7 +91,7 @@ mirror_subdirs() {
 	xargs -- wget ${TIMESTAMPING} --protocol-directories --force-directories
 }
 
-mirror_one_dir "http://security.ubuntu.com/ ubuntu/pool/main/l/linux/"
+mirror_one_dir "http://security.ubuntu.com/ubuntu/pool/main/l/linux/"
 mirror_subdirs "http://kernel.ubuntu.com/~kernel-ppa/mainline"
 # TODO?: mirror https://bugs.launchpad.net/~ canonical-kernel-team/+ archive/ubuntu/ppa
 # TODO?: Investigate  linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/ ~canonical-kernel-team/+ archive/ubuntu/ppa/+build/ 9593535

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -40,9 +40,6 @@ subdirs_to_urls() {
     done
 }
 
-rm -f ${top_dir}/index.html
-wget --force-directories --protocol-directories ${top_url}/
-
 echo_one_per_line() {
     local word
     for word in "$@" ; do
@@ -58,6 +55,9 @@ get_subdir_index_files() {
 	      --protocol-directories --force-directories \
 	      --accept=index.html --recursive
 }
+
+rm -f ${top_dir}/index.html
+wget --force-directories --protocol-directories ${top_url}/
 
 # FIXME.  This breaks for subdirectory names containing spaces.
 subdirs=$(extract_subdirs <  ${top_dir}/index.html | versions_above_3_9)

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -62,8 +62,23 @@ url_to_dir()
     echo "$prefix/$suffix"
 }
 
+remove_index_html_mirror_files() {
+    local url dir
+    for url in "$@" ; do
+	case "$url" in
+	    *://* )
+		dir=$(url_to_dir "$url")
+		rm -f "$dir/index.html" || true ;;
+	esac
+    done
+}
+
 mirror_one_dir() {
-     wget ${TIMESTAMPING} --protocol-directories --force-directories \
+    if [ ".${TIMESTAMPING}" = ".--no-clobber" ] ; then
+	remove_index_html_mirror_files "$@"
+    fi
+
+    wget ${TIMESTAMPING} --protocol-directories --force-directories \
 	 --recursive --level=1 \
 	 --accept-regex=".*/index.html|(linux-headers-${above_3_9_regexp}.*(${arch}|all)\.deb)\$" \
 	 "$@"

--- a/portworx-mirror-server/pwx-mirror-config.sh
+++ b/portworx-mirror-server/pwx-mirror-config.sh
@@ -2,6 +2,9 @@
 # This file is intended to be sourced from a shell script
 
 scriptsdir=$PWD
-mirrordir=/home/ftp/mirrors
-web_mirrordir=/var/www/html/mirrors
+ftp_top=/home/ftp
+web_top=/var/www/html
+
+mirrordir=${ftp_top}/mirrors
+web_mirrordir=${web_top}/mirrors
 


### PR DESCRIPTION
This pull adds many fixes and clean-ups that finally make the new kernel build system run, at least for the Ubuntu repositories kernels.ubuntu.com and newly added security.ubuntu.com.

Some of the changes are not specific to Ubuntu.

