### PR TITLE
Make Centos testing almost work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,9 @@
 # TODO list
 
 1. Add some "browse by date" links for /home/ftp/build-results/pxfuse-*.
+
 2. Investigate adding support for mirroring Ubuntu repository https://bugs.launchpad.net/~canonical-kernel-team/+archive/ubuntu/ppa
+
 3. Investigate linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/ ~canonical-kernel-team/+archive/ubuntu/ppa/+build/9593535
+
+4. Make build logs directory tree more human readable by replacing some of the first elements of the directory paths with single element nicknames (for example, "https/kernel.ubuntu.com/~kernel-ppa/..." might become "ubuntu_kernel").

--- a/portworx-kernel-tester/container_driver.lxc.sh
+++ b/portworx-kernel-tester/container_driver.lxc.sh
@@ -44,7 +44,7 @@ start_container_lxc() {
     case "$distro" in
 	ubuntu ) release="xenial" ;;
 	debian ) release="jessie" ;;
-	centos ) release="Core" ;;
+	centos ) release="7" ;;
 	* )
 	    echo "start_container_lxc: Unknown distribution \"${distro}\"." >&2
 	    echo "Failing." >&2

--- a/portworx-kernel-tester/distro_driver.centos.sh
+++ b/portworx-kernel-tester/distro_driver.centos.sh
@@ -10,7 +10,7 @@ install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
 install_pkg_files_centos()        { install_pkg_files_rpm         "$@" ; }
 uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
-test_kernel_pkgs_func()           { test_kernel_pkgs_func_default "$@" ; }
+test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }
 
 walk_mirror_centos() {
     local mirror_tree="$1"

--- a/portworx-kernel-tester/distro_driver.centos.sh
+++ b/portworx-kernel-tester/distro_driver.centos.sh
@@ -7,7 +7,7 @@ dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }
 pkg_files_to_kernel_dirs_centos() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_centos()       { pkg_files_to_names_rpm        "$@" ; }
 install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
-install_pkg_files_centos()        { install_pkg_files_rpm         "$@" ; }
+install_pkgs_dir_centos()         { install_pkgs_dir_rpm          "$@" ; }
 uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }

--- a/portworx-kernel-tester/distro_driver.centos.sh
+++ b/portworx-kernel-tester/distro_driver.centos.sh
@@ -27,7 +27,7 @@ walk_mirror_centos() {
     return_status=0
     ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-*-headers-*.${rpm_arch}.rpm" -type f -print0 ) |
     while read -r -d $'\0' file ; do
-        if ! "$@" "$mirror_tree" "$file" ; then
+        if ! "$@" "$file" ; then
 	    return_status=$?
 	fi
     done

--- a/portworx-kernel-tester/distro_driver.centos.sh
+++ b/portworx-kernel-tester/distro_driver.centos.sh
@@ -14,8 +14,7 @@ test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }
 
 walk_mirror_centos() {
     local mirror_tree="$1"
-    local file
-    local rpm_arch
+    local file rpm_arch return_status
 
     shift 1
 
@@ -25,8 +24,12 @@ walk_mirror_centos() {
 	rpm_arch="$arch"
     fi
 
+    return_status=0
     ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-*-headers-*.${rpm_arch}.rpm" -type f -print0 ) |
     while read -r -d $'\0' file ; do
-        "$@" "$mirror_tree" "$file"
+        if ! "$@" "$mirror_tree" "$file" ; then
+	    return_status=$?
+	fi
     done
+    return $return_status
 }

--- a/portworx-kernel-tester/distro_driver.deb.sh
+++ b/portworx-kernel-tester/distro_driver.deb.sh
@@ -30,7 +30,22 @@ pkg_files_to_names_deb () {
     done
 }
 
-install_pkgs_deb()      { in_container apt-get install --quiet --yes "$@" ; }
-install_pkgs_dir_deb()  { in_container sh -c "dpkg --install --force-all $1/*" ; }
-uninstall_pkgs_deb()    { in_container dpkg --remove "$@" ; }
-pkgs_update_deb()       { in_container apt-get update --quiet --yes ; }
+install_pkgs_deb()      {
+    in_container apt-get install --quiet --yes --force-yes "$@"
+}
+
+# uninstall_pkgs_deb()    { in_container dpkg --remove "$@" ; }
+uninstall_pkgs_deb()    {
+    in_container apt-get remove --quiet --yes --force-yes "$@"
+}
+
+pkgs_update_deb()       {
+    in_container apt-get update --quiet --yes --force-yes
+}
+
+install_pkgs_dir_deb()  {
+    in_container sh -c "dpkg --install --force-all $1/*"
+    # in_container apt-get --fix-broken install --quiet --yes --force-yes || true
+    in_container apt-get --fix-broken install --yes --force-yes || true
+    # ^^^ Try to install any missing dependencies.
+}

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -64,8 +64,6 @@ debian_process_common_deb_file()
 	    fi
 	done
 
-	# FIXME.  Skip here if the build was already done.
-
 	deps=$(debian_pkgs_to_dependencies $header_files)
 	depfiles=$(debian_find_pkgs_in_mirror "$mirror_tree" $deps)
 

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -73,7 +73,9 @@ debian_process_common_deb_file()
 	    fi
 	done
 
-	deps=$(debian_pkgs_to_dependencies $header_files)
+	deps=$(debian_pkgs_to_dependencies $header_files |
+		      egrep -v '^linux-headers-' )
+
 	depfiles=$(debian_find_pkgs_in_mirror "$mirror_tree" $deps)
 
 	"$@" $header_files $depfiles

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -74,11 +74,15 @@ debian_process_common_deb_file()
 
 walk_mirror_debian() {
     local mirror_tree="$1"
-    local file
+    local file return_status
 
     shift 1
+    return_status=0
     ( cd "$mirror_tree" && find . -name "linux-headers-*-common_*_${arch}.deb" -type f -print0 ) |
     while read -r -d $'\0' file ; do
-        debian_process_common_deb_file "$mirror_tree" "$file" "$@" < /dev/null
+        if ! debian_process_common_deb_file "$mirror_tree" "$file" "$@" < /dev/null ; then
+	    return_status=$?
+	fi
     done
+    return $return_status
 }

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -35,7 +35,7 @@ debian_find_pkgs_in_mirror() {
 
     shift 1
     for pkgname in "$@" ; do
-	find "$mirror_tree" -name "${pkgname}-*.deb" | sort --unique | tail -1
+	find "$mirror_tree" -name "${pkgname}_*_${arch}.deb" | sort --unique | tail -1
 	# "sort | tail -1" selects the latest revision.
     done
 }

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -91,7 +91,11 @@ walk_mirror_debian() {
     find "$mirror_tree" -name '*.deb' -type f | sort -u > "$debian_find_txt"
     cp "$debian_find_txt" /tmp/ # AJR
 
-    ( cd "$mirror_tree" && find . -name "linux-headers-*-common_*_${arch}.deb" -type f -print0 ) |
+    # Only process kernel headers version 3.10 and later:
+    ( cd "$mirror_tree" &&
+      find . \( -name "linux-headers-3.[1-9][0-9]*-common_*_${arch}.deb" -o \
+	        -name "linux-headers-[4-9]*-common_*_${arch}.deb" \) \
+	     -type f -print0 ) |
     while read -r -d $'\0' file ; do
         if ! debian_process_common_deb_file "$mirror_tree" "$file" "$@" < /dev/null ; then
 	    return_status=$?

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -18,7 +18,7 @@ debian_pkgs_to_dependencies() {
 	dpkg --info "$pkgfile"
     done |
 	egrep '^ Depends: ' |
-	sed 's/^ Depends: //;s/ /\n/g' |
+	sed 's/(.*)/ /g;s/,/ /g;s/^ Depends: //;s/ /\n/g' |
 	sort -u
 }
 

--- a/portworx-kernel-tester/distro_driver.debian.sh
+++ b/portworx-kernel-tester/distro_driver.debian.sh
@@ -3,14 +3,21 @@
 
 # For now, just default everything to the common Debian drivers.
 
+debian_tmpdir=/tmp/pwx-kernel-tester.distro-driver.debian.$$
+debian_find_txt="${debian_tmpdir}/find.sorted.txt"
+
 dist_init_container_debian()      { dist_init_container_deb       "$@" ; }
-pkg_files_to_kernel_dirs_debian() { pkg_files_to_kernel_dirs_deb  "$@" ; }
 pkg_files_to_names_debian()       { pkg_files_to_names_deb        "$@" ; }
 install_pkgs_debian()             { install_pkgs_deb              "$@" ; }
 install_pkgs_dir_debian()         { install_pkgs_dir_deb          "$@" ; }
 uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_debian()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_debian()    { test_kernel_pkgs_func_default "$@" ; }
+
+pkg_files_to_kernel_dirs_debian() {
+    pkg_files_to_kernel_dirs_deb "$@" | egrep -v -- '-common$'
+}
+
 
 debian_pkgs_to_dependencies() {
     local pkgfile
@@ -35,9 +42,11 @@ debian_find_pkgs_in_mirror() {
 
     shift 1
     for pkgname in "$@" ; do
-	find "$mirror_tree" -name "${pkgname}_*_${arch}.deb" | sort --unique | tail -1
-	# "sort | tail -1" selects the latest revision.
-    done
+	fgrep "/${pkgname}_" < "$debian_find_txt" |
+	    egrep "_${arch}.deb\$" |
+	    tail -1
+    done |
+	sort -u
 }
 
 debian_process_common_deb_file()
@@ -67,7 +76,7 @@ debian_process_common_deb_file()
 	deps=$(debian_pkgs_to_dependencies $header_files)
 	depfiles=$(debian_find_pkgs_in_mirror "$mirror_tree" $deps)
 
-	"$@" $(echo_word_per_line $header_files $depfiles | sort --unique)
+	"$@" $header_files $depfiles
 }
 
 walk_mirror_debian() {
@@ -76,11 +85,18 @@ walk_mirror_debian() {
 
     shift 1
     return_status=0
+    mkdir -p "$debian_tmpdir"
+    # ( cd "$mirror_tree" && find . -name '*.deb' -type f | sort -u ) \
+    #	> "$debian_find_txt"
+    find "$mirror_tree" -name '*.deb' -type f | sort -u > "$debian_find_txt"
+    cp "$debian_find_txt" /tmp/ # AJR
+
     ( cd "$mirror_tree" && find . -name "linux-headers-*-common_*_${arch}.deb" -type f -print0 ) |
     while read -r -d $'\0' file ; do
         if ! debian_process_common_deb_file "$mirror_tree" "$file" "$@" < /dev/null ; then
 	    return_status=$?
 	fi
     done
+    rm -rf "$debian_tmpdir"
     return $return_status
 }

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -19,8 +19,8 @@ pkg_files_to_names_rpm () {
     rpm --query --package "$@"
 }
 
-install_pkgs_rpm()            { in_container yum install "$@" ; }
-install_pkg_files_rpm()       { in_container rpm --install "$@" ; }
-uninstall_pkgs_rpm()          { in_container rpm --erase "$@" ; }
+install_pkgs_rpm() { in_container yum install "$@" ; }
+install_pkg_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
+uninstall_pkgs_rpm() { in_container rpm --erase "$@" ; }
 
 pkgs_update_rpm() { in_container "yum update" ; }

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -17,6 +17,6 @@ pkg_files_to_names_rpm () {
 
 install_pkgs_rpm()            { in_container yum install "$@" ; }
 install_pkg_files_rpm()       { in_container rpm --install "$@" ; }
-uninstall_pkgs_rpm()          { in_container rpm --remove "$@" ; }
+uninstall_pkgs_rpm()          { in_container rpm --erase "$@" ; }
 
 pkgs_update_rpm() { in_container "yum update" ; }

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -20,6 +20,6 @@ pkg_files_to_names_rpm () {
 }
 
 install_pkgs_rpm() { in_container yum --assumeyes --quiet install "$@" ; }
-install_pkg_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
+install_pkgs_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
 uninstall_pkgs_rpm() { in_container rpm --erase "$@" ; }
 pkgs_update_rpm() { in_container yum --assumeyes --quiet update ; }

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -22,5 +22,4 @@ pkg_files_to_names_rpm () {
 install_pkgs_rpm() { in_container yum --assumeyes --quiet install "$@" ; }
 install_pkg_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
 uninstall_pkgs_rpm() { in_container rpm --erase "$@" ; }
-
 pkgs_update_rpm() { in_container yum --assumeyes --quiet update ; }

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -1,6 +1,10 @@
 # This is not a standalone program.  It is a library to be sourced by a shell
 # script.
 
+dist_init_container_rpm() {
+    install_pkgs_rpm autoconf g++ gcc git make tar
+}
+
 pkg_files_to_kernel_dirs_rpm() {
     rpm --query --list --package "$@" |
 	egrep ^d |

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -19,8 +19,8 @@ pkg_files_to_names_rpm () {
     rpm --query --package "$@"
 }
 
-install_pkgs_rpm() { in_container yum install "$@" ; }
+install_pkgs_rpm() { in_container yum --assumeyes --quiet install "$@" ; }
 install_pkg_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
 uninstall_pkgs_rpm() { in_container rpm --erase "$@" ; }
 
-pkgs_update_rpm() { in_container "yum update" ; }
+pkgs_update_rpm() { in_container yum --assumeyes --quiet update ; }

--- a/portworx-kernel-tester/distro_driver.rpm.sh
+++ b/portworx-kernel-tester/distro_driver.rpm.sh
@@ -19,7 +19,7 @@ pkg_files_to_names_rpm () {
     rpm --query --package "$@"
 }
 
-install_pkgs_rpm() { in_container yum --assumeyes --quiet install "$@" ; }
+install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
 install_pkgs_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
-uninstall_pkgs_rpm() { in_container rpm --erase "$@" ; }
-pkgs_update_rpm() { in_container yum --assumeyes --quiet update ; }
+uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
+pkgs_update_rpm()      { in_container yum --assumeyes --quiet update ; }

--- a/portworx-kernel-tester/distro_driver.sh
+++ b/portworx-kernel-tester/distro_driver.sh
@@ -25,8 +25,6 @@ test_kernel_pkgs_func_loggable() {
     local result filename real dirname basename headers_dir
     local force=false
 
-    echo "AJR test_kernel_pkgs_func_loggable called with arguments $*" >&2
-
     container_tmpdir="$1"
     result_logdir="$2"
 

--- a/portworx-kernel-tester/distro_driver.sh
+++ b/portworx-kernel-tester/distro_driver.sh
@@ -25,6 +25,8 @@ test_kernel_pkgs_func_loggable() {
     local result filename real dirname basename headers_dir
     local force=false
 
+    echo "AJR test_kernel_pkgs_func_loggable called with arguments $*" >&2
+
     container_tmpdir="$1"
     result_logdir="$2"
 

--- a/portworx-kernel-tester/distro_driver.ubuntu.sh
+++ b/portworx-kernel-tester/distro_driver.ubuntu.sh
@@ -16,20 +16,24 @@ test_kernel_pkgs_func_ubuntu()    { test_kernel_pkgs_func_default "$@" ; }
 ubuntu_process_non_arch_file()
 {
         local file="$1"
-        local dir pkg_name dir arch_file
+        local dir pkg_name dir arch_file return_status
 
 	shift 1
 
         pkg_name=$(pkg_files_to_names_ubuntu "$file" | head -1)
         dir=${file%/*}
 
+	return_status=0
         for arch_file in ${dir}/${pkg_name}-*_${arch}.deb ; do
             if [[ ! -e "$arch_file" ]] ; then
                 echo "No architecuture-specific matches for $file" >&2
                 continue
             fi
-	    "$@" "$arch_file" "$file"
+	    if ! "$@" "$arch_file" "$file" ; then
+		return_status=$?
+	    fi
         done
+	return $return_status
 }
 
 walk_mirror_ubuntu() {

--- a/portworx-kernel-tester/distro_driver.ubuntu.sh
+++ b/portworx-kernel-tester/distro_driver.ubuntu.sh
@@ -34,11 +34,16 @@ ubuntu_process_non_arch_file()
 
 walk_mirror_ubuntu() {
     local mirror_tree="$1"
-    local file
+    local file return_status
+
 
     shift 1
+    return_status=0
     find "$mirror_tree" -name 'linux-headers-*_all.deb' -type f -print0 |
     while read -r -d $'\0' file ; do
-        ubuntu_process_non_arch_file "$file" "$@" < /dev/null
+        if ! ubuntu_process_non_arch_file "$file" "$@" < /dev/null ; then
+	    return_status=$?
+	fi
     done
+    return $return_status
 }

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -19,7 +19,7 @@ install_scripts() {
     done
 }
 
-apt-get install -y rpm
+apt-get install --yes --quiet rpm
 # Needed for Centos support, for extracting information from .rpm files.
 
 mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}"

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -19,6 +19,9 @@ install_scripts() {
     done
 }
 
+apt-get install -y rpm
+# Needed for Centos support, for extracting information from .rpm files.
+
 mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}"
 
 install_scripts "${scriptsdir}" \

--- a/portworx-kernel-tester/install.sh
+++ b/portworx-kernel-tester/install.sh
@@ -29,7 +29,8 @@ install_scripts "${scriptsdir}" \
 		container_driver.sh \
 		distro_driver.*.sh \
 		distro_driver.sh \
-		pwx_test_kernels.cron_script.sh
+		pwx_test_kernels.cron_script.sh \
+		pwx_update_pxfuse_by_date.sh
 
 install_scripts "${bindir}" \
 		pwx_test_kernel_pkgs.sh \
@@ -37,7 +38,8 @@ install_scripts "${bindir}" \
 
 chmod a+x "${bindir}/pwx_test_kernel_pkgs.sh" \
       "${bindir}/pwx_test_kernels_in_mirror.sh" \
-      "${scriptsdir}/pwx_test_kernels.cron_script.sh"
+      "${scriptsdir}/pwx_test_kernels.cron_script.sh" \
+      "${scriptsdir}/pwx_update_pxfuse_by_date.sh"
 
 old_crontab=$( ( crontab -u root -l 2> /dev/null ) |
 	      egrep -v pwx_test_kernels.cron_script.sh |

--- a/portworx-kernel-tester/pwx_test_kernel_pkgs.sh
+++ b/portworx-kernel-tester/pwx_test_kernel_pkgs.sh
@@ -54,9 +54,7 @@ prepare_pxfuse_dir() {
 }
 
 main() {
-    local kernel_dir
     start_container dist_init_container
-    kernel_dir=$(pkg_files_to_kernel_dirs "$@" | head -1)
 
     test_kernel_pkgs_func "$remote_tmp_dir" "$logdir" "$@"
     result=$?

--- a/portworx-kernel-tester/pwx_test_kernel_pkgs.sh
+++ b/portworx-kernel-tester/pwx_test_kernel_pkgs.sh
@@ -58,7 +58,6 @@ main() {
     start_container dist_init_container
     kernel_dir=$(pkg_files_to_kernel_dirs "$@" | head -1)
 
-    start_container dist_init_container
     test_kernel_pkgs_func "$remote_tmp_dir" "$logdir" "$@"
     result=$?
 

--- a/portworx-kernel-tester/pwx_test_kernel_pkgs.sh
+++ b/portworx-kernel-tester/pwx_test_kernel_pkgs.sh
@@ -54,6 +54,7 @@ prepare_pxfuse_dir() {
 }
 
 main() {
+    local result
     start_container dist_init_container
 
     test_kernel_pkgs_func "$remote_tmp_dir" "$logdir" "$@"

--- a/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
+++ b/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+scriptsdir=$PWD
+
 logdir=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 
 exec > "$logdir" 2>&1
@@ -10,5 +12,7 @@ for distribution in centos debian ubuntu ; do
 	result=$?
     fi
 done
+
+$scriptsdir/pwx_update_pxfuse_by_date.sh
 
 exit $result

--- a/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
+++ b/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
@@ -4,7 +4,6 @@ logdir=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 
 exec > "$logdir" 2>&1
 
-#for distribution in centos debian ubuntu ; do
-for dist in centos ubuntu ; do
+for distribution in centos debian ubuntu ; do
     pwx_test_kernels_in_mirror.sh --containers=lxc --distribution="$dist"
 done

--- a/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
+++ b/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
@@ -4,6 +4,11 @@ logdir=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 
 exec > "$logdir" 2>&1
 
+result=0
 for distribution in centos debian ubuntu ; do
-    pwx_test_kernels_in_mirror.sh --containers=lxc --distribution="$dist"
+    if ! pwx_test_kernels_in_mirror.sh --containers=lxc --distribution="$dist" ; then
+	result=$?
+    fi
 done
+
+exit $result

--- a/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
+++ b/portworx-kernel-tester/pwx_test_kernels.cron_script.sh
@@ -5,6 +5,6 @@ logdir=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 exec > "$logdir" 2>&1
 
 #for distribution in centos debian ubuntu ; do
-for dist in ubuntu ; do
+for dist in centos ubuntu ; do
     pwx_test_kernels_in_mirror.sh --containers=lxc --distribution="$dist"
 done

--- a/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
+++ b/portworx-kernel-tester/pwx_test_kernels_in_mirror.sh
@@ -5,8 +5,8 @@ scriptsdir=$PWD
 build_results_dir=$PWD/build-results
 
 usage() {
-    echo "Usage: test_kernels_in_mirror.sh [ --distribution=dist ] "
-    echo "       [ --containers=container_system] [ --logdir=dir ] "
+    echo "Usage: test_kernels_in_mirror.sh [ --distribution=dist ]"
+    echo "       [ --containers=container_system] [ --logdir=dir ]"
     echo "       [ --mirror-top=topdir ]"
     echo "       [ --pxfuse=pxfuse_src_directory ] [ mirror_dirs... ]"
     echo ""

--- a/portworx-kernel-tester/pwx_update_pxfuse_by_date.sh
+++ b/portworx-kernel-tester/pwx_update_pxfuse_by_date.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+datedir=/home/ftp/build-results/pxfuse.by-date
+rm -rf "$datedir"
+mkdir -p "$datedir"
+cd "$datedir" || exit $?
+
+for dir in ../pxfuse-*/ ; do
+    dir_no_slash=${dir%/}
+    prefix=$( (TZ='' stat --format=%y "$dir_no_slash") | sed 's/ +0000$//;s/ /_/g' )
+    suffix=${dir_no_slash#../}
+    ln -s "$dir" "${prefix}-${suffix}"
+done


### PR DESCRIPTION
These changes make the kernel module build testing almost work for Centos and include other clean up or fixes not specific to Centos that I made incidentally.

Within the Centos container, the builds still abort, complaining about some package dependencies, but testing of the few Centos kernels that I currently mirror is pretty close now.

Probably the most important changes in this batch that are not related to Centos are some fixes to cases where a build could fail, but a function that ran multiple builds might return success if the last build in the group succeeded.  Now, I believe, in all cases, the only way a function that tests multiple kernel headers returns success is if all of the tests succeed.