### PR TITLE
Add a second Centos mirror and first Fedora mirror, and try (but currently fail) to test them

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,3 +7,6 @@
 3. Investigate linux-headers-4.2.0-36-generic_4.2.0-36.41_amd64.deb found by Ankit on https://bugs.launchpad.net/ ~canonical-kernel-team/+archive/ubuntu/ppa/+build/9593535
 
 4. Make build logs directory tree more human readable by replacing some of the first elements of the directory paths with single element nicknames (for example, "https/kernel.ubuntu.com/~kernel-ppa/..." might become "ubuntu_kernel").
+
+5. Maybe deal with kernel source-only RPM's on vault.centos.org.  Apparently the generated kernel header RPM's are not archived.  Maybe we should rebuild all of these from source.
+

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -8,7 +8,7 @@ crontab.txt: crontab.txt.in
 
 install_mirror_scripts: all
 	mkdir -p ${scriptsdir}
-	for file in mirror-kernels.*.sh test-kernels.*.sh docker-host-test-kernel-build.sh cron-script.sh test-kernel-in-docker.sh pwx-mirror-config.sh ; do \
+	for file in mirror-kernels.*.sh test-kernels.*.sh docker-host-test-kernel-build.sh cron-script.sh test-kernel-in-docker.sh pwx-mirror-config.sh pwx-mirror-util.sh ; do \
 	    sed "s|^scriptsdir=.*$$|scriptsdir=${scriptsdir}|g" \
 		< "$$file" > "${scriptsdir}/$$file" ; \
 	done

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -12,10 +12,6 @@ mkdir -p ${mirrordir}
 # TIMESTAMPING=--timestamping
 TIMESTAMPING='--no-clobber --no-use-server-timestamps'
 
-do_wget() {
-    wget --no-parent ${TIMESTAMPING} "$@"
-}
-
 newlines_around_angle_brackets() {
     sed 's/</\'$'\n''</g;s/>/>\'$'\n''/g;'
 }

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -5,6 +5,7 @@ arch=x86_64
 
 scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
 cd ${mirrordir} || exit $?
 mkdir -p ${mirrordir}
 
@@ -45,9 +46,8 @@ echo_one_per_line() {
 }
 
 mirror_el_repo() {
-    local top=elrepo.org/linux/kernel/
-    local top_url=http://$top
-    local top_dir=http/$top
+    local top_url=http://elrepo.org/linux/kernel/
+    local top_dir=$(url_to_dir "$top_url")
 
     wget --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive \

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -20,7 +20,7 @@ mirror_el_repo() {
     local top_url=http://elrepo.org/linux/kernel/
     local top_dir=$(url_to_dir "$top_url")
 
-    wget --no-parent ${TIMESTAMPING} -e robots=off \
+    wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive \
 	 --accept-regex='.*/(index.html)?$' \
 	 ${top_url}
@@ -35,4 +35,31 @@ mirror_el_repo() {
 	      --protocol-directories --force-directories
 }
 
+mirror_mirror_centos_org() {
+    local top_url=http://mirror.centos.org/centos/
+    local top_dir=$(url_to_dir "$top_url")
+
+    wget --quiet --protocol-directories --force-directories \
+	  "${top_url}"
+
+    extract_subdirs < "$top_dir/index.html" |
+	egrep '^[0-9]' |
+	sed "s|^|${top_url}|;s|\$|/os/x86_64/Packages/|" |
+	xargs wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
+	 --protocol-directories --force-directories --recursive --level=1 \
+	 --accept-regex="/(index.html)|(kernel-.*headers.*\.rpm)"
+
+    # FIXME.  The following URL, that should filter out kernels before
+    # 3.10, is not working:
+    #
+    # --accept-regex="/(index.html)|(kernel-${above_3_9_regexp}(.*-)?headers(.*-.*-.*)?\..*\.rpm)"
+}
+
+
+# TODO? mirror vault.centos.org, but it only contains source RPM's.  The
+# kernel-headers RPM's that we use are apparently non-source RPM's
+# generated from kernel source RPM's.
+
+# mirror_vault_centos_org
+mirror_mirror_centos_org
 mirror_el_repo

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -12,26 +12,8 @@ mkdir -p ${mirrordir}
 # TIMESTAMPING=--timestamping
 TIMESTAMPING='--no-clobber --no-use-server-timestamps'
 
-newlines_around_angle_brackets() {
-    sed 's/</\'$'\n''</g;s/>/>\'$'\n''/g;'
-}
-
-# I think there is a perl program named extract-urls that will do this better.
-extract_subdirs() {
-    newlines_around_angle_brackets |
-	egrep '^<a href="' | sed 's/^[^"]*"//;s/"[^"]*$//'
-}
-
 versions_above_3_9 () {
     egrep '^v(4|3\.[1-9][0-9]).*/$'
-}
-
-subdirs_to_urls() {
-    local top_url="$1"
-
-    while read subdir ; do
-        echo "$top_url/$subdir"
-    done
 }
 
 mirror_el_repo() {

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -44,14 +44,6 @@ echo_one_per_line() {
     done
 }
 
-url_to_dir()
-{
-    local url="$1"
-    local prefix="${url%%://*}"
-    local suffix="${url#*://}"
-    echo "$prefix/$suffix"
-}
-
 mirror_el_repo() {
     local top=elrepo.org/linux/kernel/
     local top_url=http://$top

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -38,13 +38,6 @@ subdirs_to_urls() {
     done
 }
 
-echo_one_per_line() {
-    local word
-    for word in "$@" ; do
-	echo "$word"
-    done
-}
-
 mirror_el_repo() {
     local top_url=http://elrepo.org/linux/kernel/
     local top_dir=$(url_to_dir "$top_url")

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -20,15 +20,22 @@ mirror_el_repo() {
     local top_url=http://elrepo.org/linux/kernel/
     local top_dir=$(url_to_dir "$top_url")
 
+    local rpm_arch
+
+    case "$arch" in
+	amd64 ) rpm_arch="x86_64" ;;
+	* ) rpm_arch="$arch" ;;
+    esac
+
     wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive \
 	 --accept-regex='.*/(index.html)?$' \
 	 ${top_url}
 
-    for dir in ${top_dir}/*/${arch}/RPMS/ ; do
+    for dir in ${top_dir}/*/${rpm_arch}/RPMS/ ; do
 	echo ''
 	extract_subdirs < $dir/index.html |
-	    egrep "^kernel-.*headers-.*.${arch}.rpm$" |
+	    egrep "^kernel-.*headers-.*.${rpm_arch}.rpm$" |
 	    subdirs_to_urls http://${dir#http/}
     done |
 	xargs -- wget --no-parent ${TIMESTAMPING} \
@@ -49,10 +56,11 @@ mirror_mirror_centos_org() {
 	 --protocol-directories --force-directories --recursive --level=1 \
 	 --accept-regex="/(index.html)|(kernel-.*headers.*\.rpm)"
 
-    # FIXME.  The following URL, that should filter out kernels before
-    # 3.10, is not working:
+    # FIXME.  The following regular expresion might filter out kernels before
+    # 3.10.  It is modified from one that was not working, but maybe this
+    # version might work.
     #
-    # --accept-regex="/(index.html)|(kernel-${above_3_9_regexp}(.*-)?headers(.*-.*-.*)?\..*\.rpm)"
+    # --accept-regex="/(index.html)|(kernel-(.*-)?headers-${above_3_9_regexp}(.*-.*-.*)?\..*\.rpm)"
 }
 
 

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -5,6 +5,7 @@
 
 scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
 mkdir -p ${mirrordir}
 cd ${mirrordir} || exit $?
 
@@ -62,13 +63,6 @@ directory_url_to_filename() {
 directory_index_to_filename() {
     local index="$1"
     directory_url_to_filename "${url_array[$index]}"
-}
-
-echo_word_per_line() {
-    local word
-    for word in "$@" ; do
-	echo "$word"
-    done
 }
 
 linux_headers_after_3_9() {

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -25,17 +25,6 @@ TIMESTAMPING=--timestamping
 declare -A url_array
 declare -A kernel_header_names
 
-newlines_around_angle_brackets() {
-    sed 's/</\'$'\n''</g;s/>/>\'$'\n''/g;'
-}
-
-# I think there is a perl program named extract-urls that will do this better.
-extract_subdirs() {
-    newlines_around_angle_brackets |
-        egrep '^<a href="' |
-	sed 's/^<a href="//;s/".*$//'
-}
-
 on_or_after_linux_3_10_release_date() {
     # Linux 3.10 was released on 2013.06.30, maybe the day before in some time
     # zone)

--- a/portworx-mirror-server/mirror-kernels.fedora.sh
+++ b/portworx-mirror-server/mirror-kernels.fedora.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+#arch=i386
+arch=x86_64
+
+scriptsdir=$PWD
+. ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
+cd ${mirrordir} || exit $?
+mkdir -p ${mirrordir}
+
+# TIMESTAMPING=--timestamping
+TIMESTAMPING='--no-clobber --no-use-server-timestamps'
+#QUIET=--quiet
+QUIET=
+
+mirror_ncsu_edu() {
+    local top_url=http://ftp.linux.ncsu.edu/pub/fedora/linux/releases/
+    local top_dir=$(url_to_dir "$top_url")
+
+    wget $(QUIET) --protocol-directories --force-directories \
+	  "${top_url}"
+
+    extract_subdirs < "$top_dir/index.html" |
+	egrep '^[0-9]' |
+	sed "s|^|${top_url}|;s|\$|/Everything/x86_64/os/Packages/k/|" |
+	xargs wget $(QUIET) --no-parent ${TIMESTAMPING} -e robots=off \
+	 --protocol-directories --force-directories --recursive --level=1 \
+	 --accept-regex="/(index.html)|(kernel-.*headers.*\.rpm)"
+
+    # FIXME.  The following regular expresion might filter out kernels before
+    # 3.10.  It is modified from one that was not working, but maybe this
+    # version might work.
+    #
+    # --accept-regex="/(index.html)|(kernel-(.*-)?headers-${above_3_9_regexp}(.*-.*-.*)?\..*\.rpm)"
+}
+
+mirror_ncsu_edu

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -23,7 +23,7 @@ versions_above_3_9 () {
 
 get_subdir_index_files() {
     local top_url="$1"
-    echo_word_per_line $subdirs |
+    echo_word_per_line "$@" |
         subdirs_to_urls "${top_url}"  |
         xargs -- wget ${TIMESTAMPING} --quiet --protocol-directories \
 	      --force-directories --accept=index.html --recursive
@@ -53,7 +53,8 @@ mirror_one_dir() {
 
 mirror_subdirs() {
     local top_url="$1"
-    local top_dir
+    local top_dir subdirs
+
     top_dir=$(url_to_dir "$top_url")
     rm -f ${top_dir}/index.html
     wget --quiet --force-directories --protocol-directories ${top_url}/
@@ -61,7 +62,7 @@ mirror_subdirs() {
     # FIXME.  This breaks for subdirectory names containing spaces.
     subdirs=$(extract_subdirs <  ${top_dir}/index.html | versions_above_3_9)
 
-    get_subdir_index_files "$top_url"
+    get_subdir_index_files "$top_url" $subdirs
 
     # TODO: Change "image" to "headers"
     for subdir in $subdirs ; do

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -39,16 +39,9 @@ subdirs_to_urls() {
     done
 }
 
-echo_one_per_line() {
-    local word
-    for word in "$@" ; do
-	echo "$word"
-    done
-}
-
 get_subdir_index_files() {
     local top_url="$1"
-    echo_one_per_line $subdirs |
+    echo_word_per_line $subdirs |
         subdirs_to_urls "${top_url}"  |
         xargs -- wget ${TIMESTAMPING} --quiet --protocol-directories \
 	      --force-directories --accept=index.html --recursive

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -2,6 +2,7 @@
 
 scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
 mkdir -p ${mirrordir}
 cd ${mirrordir} || exit $?
 
@@ -51,14 +52,6 @@ get_subdir_index_files() {
         subdirs_to_urls "${top_url}"  |
         xargs -- wget ${TIMESTAMPING} --quiet --protocol-directories \
 	      --force-directories --accept=index.html --recursive
-}
-
-url_to_dir()
-{
-    local url="$1"
-    local prefix="${url%%://*}"
-    local suffix="${url#*://}"
-    echo "$prefix/$suffix"
 }
 
 remove_index_html_mirror_files() {

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -15,8 +15,6 @@ arch=amd64
 #TIMESTAMPING=--timestamping
 TIMESTAMPING=--no-clobber
 
-above_3_9_regexp='(3\.[1-9][0-9]|[4-9]|[1-9][0-9])'
-
 versions_above_3_9 () {
     egrep "^v${above_3_9_regexp}.*/\$"
 }

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -17,26 +17,8 @@ TIMESTAMPING=--no-clobber
 
 above_3_9_regexp='(3\.[1-9][0-9]|[4-9]|[1-9][0-9])'
 
-newlines_around_angle_brackets() {
-    sed 's/</\'$'\n''</g;s/>/>\'$'\n''/g;'
-}
-
-# I think there is a perl program named extract-urls that will do thisb better.
-extract_subdirs() {
-    newlines_around_angle_brackets |
-	egrep '^<a href="' | sed 's/^[^"]*"//;s/"[^"]*$//'
-}
-
 versions_above_3_9 () {
     egrep "^v${above_3_9_regexp}.*/\$"
-}
-
-subdirs_to_urls() {
-    local top_url="$1"
-
-    while read subdir ; do
-        echo "$top_url/$subdir"
-    done
 }
 
 get_subdir_index_files() {

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -29,6 +29,7 @@ extract_subdirs() {
 
 subdirs_to_urls() {
     local top_url="$1"
+    local subdir
 
     while read subdir ; do
         echo "$top_url/$subdir"

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -1,0 +1,36 @@
+#
+# This file is intended to be sourced from a shell script.
+
+url_to_dir()
+{
+    local url="$1"
+    local prefix="${url%%://*}"
+    local suffix="${url#*://}"
+    echo "$prefix/$suffix"
+}
+
+echo_word_per_line() {
+    local word
+    for word in "$@" ; do
+	echo "$word"
+    done
+}
+
+newlines_around_angle_brackets() {
+    sed 's/</\'$'\n''</g;s/>/>\'$'\n''/g;'
+}
+
+# I think there is a perl program named extract-urls that will do this better.
+extract_subdirs() {
+    newlines_around_angle_brackets |
+	egrep '^<a href="' |
+	sed 's/^[^"]*"//;s/"[^"]*$//'
+}
+
+subdirs_to_urls() {
+    local top_url="$1"
+
+    while read subdir ; do
+        echo "$top_url/$subdir"
+    done
+}

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -1,5 +1,10 @@
 #
 # This file is intended to be sourced from a shell script.
+#
+# This file contains common declarations used by mirror-kernels.*.sh.
+
+# Used for selecting kernels version 3.10 or later:
+above_3_9_regexp='(3\.[1-9][0-9]|[4-9]|[1-9][0-9])'
 
 url_to_dir()
 {

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -45,6 +45,7 @@ start_container_lxc() {
 	ubuntu ) release="xenial" ;;
 	debian ) release="jessie" ;;
 	centos ) release="7" ;;
+	fedora ) release="24" ;;
 	* )
 	    echo "start_container_lxc: Unknown distribution \"${distro}\"." >&2
 	    echo "Failing." >&2

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -3,7 +3,6 @@
 
 # For now, just default everything to the common Centos drivers.
 
-dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }
 pkg_files_to_kernel_dirs_centos() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_centos()       { pkg_files_to_names_rpm        "$@" ; }
 install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
@@ -11,3 +10,8 @@ install_pkgs_dir_centos()         { install_pkgs_dir_rpm          "$@" ; }
 uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }
+
+dist_init_container_centos() {
+    dist_init_container_rpm "$@" &&
+	install_pkgs_rpm g++
+}

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -1,0 +1,13 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common Fedora drivers.
+
+dist_init_container_fedora()      { dist_init_container_rpm       "$@" ; }
+pkg_files_to_kernel_dirs_fedora() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
+pkg_files_to_names_fedora()       { pkg_files_to_names_rpm        "$@" ; }
+install_pkgs_fedora()             { install_pkgs_rpm              "$@" ; }
+install_pkgs_dir_fedora()         { install_pkgs_dir_rpm          "$@" ; }
+uninstall_pkgs_fedora()           { uninstall_pkgs_rpm            "$@" ; }
+pkgs_update_fedora()              { pkgs_update_rpm               "$@" ; }
+test_kernel_pkgs_func_fedora()    { test_kernel_pkgs_func_default "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -3,7 +3,6 @@
 
 # For now, just default everything to the common Fedora drivers.
 
-dist_init_container_fedora()      { dist_init_container_rpm       "$@" ; }
 pkg_files_to_kernel_dirs_fedora() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_fedora()       { pkg_files_to_names_rpm        "$@" ; }
 install_pkgs_fedora()             { install_pkgs_rpm              "$@" ; }
@@ -11,3 +10,8 @@ install_pkgs_dir_fedora()         { install_pkgs_dir_rpm          "$@" ; }
 uninstall_pkgs_fedora()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_fedora()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_fedora()    { test_kernel_pkgs_func_default "$@" ; }
+
+dist_init_container_fedora() {
+    dist_init_container_rpm "$@" &&
+	install_pkgs_rpm gcc-c++
+}

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -2,7 +2,7 @@
 # script.
 
 dist_init_container_rpm() {
-    install_pkgs_rpm autoconf g++ gcc git make tar
+    install_pkgs_rpm autoconf automake gcc git make tar
 }
 
 pkg_files_to_kernel_dirs_rpm() {

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -7,6 +7,7 @@
 . $scriptsdir/distro_driver.debian.sh
 . $scriptsdir/distro_driver.ubuntu.sh
 . $scriptsdir/distro_driver.centos.sh
+. $scriptsdir/distro_driver.fedora.sh
 
 
 dist_init_container()      { "dist_init_container_$distro"      "$@" ; }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -18,7 +18,7 @@ walk_mirror_centos() {
     fi
 
     return_status=0
-    ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-*-headers-*.${rpm_arch}.rpm" -type f -print0 ) |
+    ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-*headers-*.${rpm_arch}.rpm" -type f -print0 ) |
     while read -r -d $'\0' file ; do
         if ! "$@" "$file" ; then
 	    return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
@@ -18,7 +18,7 @@ walk_mirror_fedora() {
     fi
 
     return_status=0
-    ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-*-headers-*.${rpm_arch}.rpm" -type f -print0 ) |
+    ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-headers-*.${rpm_arch}.rpm" -type f -print0 ) |
     while read -r -d $'\0' file ; do
         if ! "$@" "$file" ; then
 	    return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
@@ -1,0 +1,28 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common Fedora drivers.
+
+pkg_files_to_names_fedora()       { pkg_files_to_names_rpm        "$@" ; }
+
+walk_mirror_fedora() {
+    local mirror_tree="$1"
+    local file rpm_arch return_status
+
+    shift 1
+
+    if [ ".$arch" = ".amd64" ] ; then
+	rpm_arch=x86_64
+    else
+	rpm_arch="$arch"
+    fi
+
+    return_status=0
+    ( cd "$mirror_tree" && find "$mirror_tree" -name "kernel-*-headers-*.${rpm_arch}.rpm" -type f -print0 ) |
+    while read -r -d $'\0' file ; do
+        if ! "$@" "$file" ; then
+	    return_status=$?
+	fi
+    done
+    return $return_status
+}

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -7,6 +7,7 @@
 . $scriptsdir/mirror_walk_driver.debian.sh
 . $scriptsdir/mirror_walk_driver.ubuntu.sh
 . $scriptsdir/mirror_walk_driver.centos.sh
+. $scriptsdir/mirror_walk_driver.fedora.sh
 
 
 pkg_files_to_names()       { "pkg_files_to_names_$distro"       "$@" ; }

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror.sh
@@ -62,6 +62,7 @@ if [ $# = 0 ] ; then
 		     /home/ftp/mirrors/http/mirror.centos.org/centos
 		 ;;
 	debian ) set /home/ftp/mirrors/http/snapshot.debian.org/archive/debian ;;
+	fedora ) set /home/ftp/mirrors/http/ftp.linux.ncsu.edu/pub/fedora/linux/releases ;;
 	ubuntu ) set \
 		     /home/ftp/mirrors/http/security.ubuntu.com/ubuntu/pool/main/l/linux/ \
 		     /home/ftp/mirrors/http/kernel.ubuntu.com/~kernel-ppa/mainline

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror.sh
@@ -57,7 +57,10 @@ done
 
 if [ $# = 0 ] ; then
     case "$distro" in
-	centos ) set /home/ftp/mirrors/http/elrepo.org/linux/kernel ;;
+	centos ) set \
+		     /home/ftp/mirrors/http/elrepo.org/linux/kernel \
+		     /home/ftp/mirrors/http/mirror.centos.org/centos
+		 ;;
 	debian ) set /home/ftp/mirrors/http/snapshot.debian.org/archive/debian ;;
 	ubuntu ) set \
 		     /home/ftp/mirrors/http/security.ubuntu.com/ubuntu/pool/main/l/linux/ \


### PR DESCRIPTION
1. Mirror kernels from http://mirror.centos.org/centos .  This only adds a couple of additional kernels.

2. Make the kernel test scripts also try to test the kernels on mirror.centos.org.  The Centos (and now Fedora) kernel testing does not yet work, but some changes included in this pull make it get a little further.

3. Mirror relevant Fedora kernel headers from http://ftp.linux.ncsu.edu.  This only added a few.

4. Add Fedora support to the mirror walking and kernel testing scripts.  The kernel testing scripts do not yet work with Fedora, but they seem to get to a similar point as they do with Centos.
