### PR TITLE
Compilation changes that seem to help Debian: force the test to use the standard C compiler for now

### DIFF
--- a/pwx_test_kernel_pkgs/container_driver.docker.sh
+++ b/pwx_test_kernel_pkgs/container_driver.docker.sh
@@ -4,8 +4,27 @@
 docker_pid=
 
 start_container_docker() {
-    local container_name="pwx_test_${distribution}"
-    local id
+    local container_name id
+    local release=""
+
+    while [[ $# -gt 0 ]] ; do
+	case "$1" in
+	    --release=* ) release="${1#--release=}" ;;
+	    --* ) echo "start_container_lxc: Unrecognized argument \"$1\"." >&2 ;;
+	    -- ) shift ; break ;;
+	    * ) break ;;
+	esac
+	shift
+    done
+
+    if [[ -z "$release" ]] ; then
+	echo "start_container_lxc: --release=dist_release missing." >&2
+	return 1
+    fi
+
+    # FIXME.  Support selection of distribution release.
+    # container_name="pwx_test_${distribution}_${release}"
+    container_name="pwx_test_${distribution}"
 
     systemctl start docker
     id=$(docker ps --quiet=true --all=true --filter name="${container_name}")

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -36,21 +36,25 @@ is_container_running() {
 }
 
 start_container_lxc() {
-    local release must_initialize
-    container_name="pwx_test_${distro}"
+    local must_initialize
+    local release=""
 
-    apt-get install -y lxc
+    while [[ $# -gt 0 ]] ; do
+	case "$1" in
+	    --release=* ) release="${1#--release=}" ;;
+	    --* ) echo "start_container_lxc: Unrecognized argument \"$1\"." >&2 ;;
+	    -- ) shift ; break ;;
+	    * ) break ;;
+	esac
+	shift
+    done
 
-    case "$distro" in
-	ubuntu ) release="xenial" ;;
-	debian ) release="jessie" ;;
-	centos ) release="7" ;;
-	fedora ) release="24" ;;
-	* )
-	    echo "start_container_lxc: Unknown distribution \"${distro}\"." >&2
-	    echo "Failing." >&2
-	    return 1 ;;
-    esac
+    if [[ -z "$release" ]] ; then
+	echo "start_container_lxc: --release=dist_release missing." >&2
+	return 1
+    fi
+
+    container_name="pwx_test_${distro}_${release}"
 
     lxc-ls > /dev/null 2>&1 || true
     # ^^^ Removes incompletely initialized containters
@@ -80,9 +84,9 @@ start_container_lxc() {
 }
 
 stop_container_lxc() {
-    if $use_lxc_attach ; then
-	lxc-stop --name "$container_name"
-    fi
+#    if $use_lxc_attach ; then
+#	lxc-stop --name "$container_name"
+#    fi
     true
 }
 

--- a/pwx_test_kernel_pkgs/container_driver.sh
+++ b/pwx_test_kernel_pkgs/container_driver.sh
@@ -4,9 +4,35 @@ container_system=docker	# force this default for now.
 . $scriptsdir/container_driver.docker.sh
 . $scriptsdir/container_driver.lxc.sh
 
-start_container() { "start_container_$container_system" "$@" ; }
 stop_container() { "stop_container_$container_system" "$@" ; }
 in_container() { "in_container_$container_system" "$@" ; }
+
+start_container()
+{
+    local release=""
+
+    while [[ $# -gt 0 ]] ; do
+	case "$1" in
+	    --release=* ) release="${1#--release=}" ;;
+	    -- ) shift ; break ;;
+	    --* ) echo "start_container: Unrecognized argument \"$1\"." >&2 ;;
+	    * ) break ;;
+	esac
+	shift
+    done
+
+    if [[ -z "$release" ]] ; then
+	release=$(set $(get_dist_releases) ; echo $1)
+	if [[ -z "$release" ]] ; then
+	    echo "start_container_lxc: Unable to determine default release for distribution \"${distro}\"." >&2
+	    echo "Failing." >&2
+	    return 1
+	fi
+    fi
+
+    "start_container_$container_system" --release="$release" "$@"
+}
+
 
 # Trivial implementation for the "none" driver.  You can set the
 # container command prefix to be something like "ssh -p some_port some_host"

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -7,6 +7,7 @@ pkg_files_to_kernel_dirs_centos() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_centos()       { pkg_files_to_names_rpm        "$@" ; }
 install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
 install_pkgs_dir_centos()         { install_pkgs_dir_rpm          "$@" ; }
+install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
 uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -17,3 +17,8 @@ dist_init_container_centos() {
     dist_init_container_rpm "$@" &&
 	install_pkgs_rpm g++
 }
+
+get_dist_releases_centos()
+{
+    echo "7 6"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -5,6 +5,7 @@
 
 pkg_files_to_kernel_dirs_centos() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_centos()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_centos() { pkg_files_to_dependencies_rpm "$@" ; }
 install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
 install_pkgs_dir_centos()         { install_pkgs_dir_rpm          "$@" ; }
 install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -47,6 +47,6 @@ pkgs_update_deb()       {
 install_pkgs_dir_deb()  {
     in_container sh -c "dpkg --install --force-all $1/*"
     # in_container apt-get --fix-broken install --quiet --yes --force-yes || true
-    in_container apt-get --fix-broken install --yes --force-yes || true
+    # in_container apt-get --fix-broken install --yes --force-yes || true
     # ^^^ Try to install any missing dependencies.
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -31,6 +31,16 @@ pkg_files_to_names_deb () {
     done
 }
 
+pkg_files_to_dependencies_deb() {
+    local pkgfile
+    for pkgfile in "$@" ; do
+	dpkg --info "$pkgfile"
+    done |
+	egrep '^ Depends: ' |
+	sed 's/(.*)/ /g;s/,/ /g;s/^ Depends: //;s/ /\n/g' |
+	sort -u
+}
+
 install_pkgs_deb()      {
     in_container apt-get install --quiet --yes --force-yes "$@"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.debian.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.debian.sh
@@ -8,6 +8,7 @@ debian_find_txt="${debian_tmpdir}/find.sorted.txt"
 
 dist_init_container_debian()      { dist_init_container_deb       "$@" ; }
 pkg_files_to_names_debian()       { pkg_files_to_names_deb        "$@" ; }
+pkg_files_to_dependencies_debian() { pkg_files_to_dependencies_deb "$@" ; }
 install_pkgs_debian()             { install_pkgs_deb              "$@" ; }
 install_pkgs_dir_debian()         { install_pkgs_dir_deb          "$@" ; }
 uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.debian.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.debian.sh
@@ -15,6 +15,11 @@ uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_debian()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_debian()    { test_kernel_pkgs_func_default "$@" ; }
 
+get_dist_releases_debian()
+{
+    echo "jessie stretch"
+}
+
 pkg_files_to_kernel_dirs_debian() {
     local result=$(pkg_files_to_kernel_dirs_deb "$@" | egrep -v -- '-common$')
     pkg_files_to_kernel_dirs_deb "$@" | egrep -v -- '-common$'

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -16,3 +16,8 @@ dist_init_container_fedora() {
     dist_init_container_rpm "$@" &&
 	install_pkgs_rpm gcc-c++
 }
+
+get_dist_releases_fedora()
+{
+    echo "24"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -5,6 +5,7 @@
 
 pkg_files_to_kernel_dirs_fedora() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_fedora()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_fedora() { pkg_files_to_dependencies_rpm "$@" ; }
 install_pkgs_fedora()             { install_pkgs_rpm              "$@" ; }
 install_pkgs_dir_fedora()         { install_pkgs_dir_rpm          "$@" ; }
 uninstall_pkgs_fedora()           { uninstall_pkgs_rpm            "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -27,7 +27,6 @@ pkg_files_to_dependencies_rpm() {
 	sort -u
 }
 
-
 install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
 install_pkgs_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
 uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -19,6 +19,15 @@ pkg_files_to_names_rpm () {
     rpm --query --package "$@"
 }
 
+pkg_files_to_dependencies_rpm() {
+    local pkgfile
+    for pkgfile in "$@" ; do
+	rpm -qpR "$pkgfile"
+    done |
+	sort -u
+}
+
+
 install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
 install_pkgs_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
 uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -70,7 +70,7 @@ test_kernel_pkgs_func_loggable() {
 		 "cd ${container_tmpdir}/pxfuse_dir && \
                   autoreconf && \
                   ./configure && \
-                  make KERNELPATH=$headers_dir"
+                  make KERNELPATH=$headers_dir CC=\"gcc -fno-pie\""
 
     result=$?
     echo "test_kernel_pkgs_func_default: build_exit_code=$result" >&2

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -102,9 +102,8 @@ test_kernel_pkgs_func_default() {
 
     if [[ -e "$result_logdir/done" ]] && ! $force ; then
 	echo "test_kernel_pkgs_func_default: $result_logdir/done exists.  Skipping."
+    else
+	mkdir -p "$result_logdir"
+	test_kernel_pkgs_func_loggable "$@" > "$result_logdir/build.log" 2>&1
     fi
-
-    mkdir -p "$result_logdir"
-    test_kernel_pkgs_func_loggable "$@" \
-	> "$result_logdir/build.log" 2>&1
 }

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -13,6 +13,7 @@
 dist_init_container()      { "dist_init_container_$distro"      "$@" ; }
 pkg_files_to_kernel_dirs() { "pkg_files_to_kernel_dirs_$distro" "$@" ; }
 pkg_files_to_names()       { "pkg_files_to_names_$distro"       "$@" ; }
+pkg_files_to_dependencies() { "pkg_files_to_dependencies_$distro" "$@" ; }
 install_pkgs()             { "install_pkgs_$distro"             "$@" ; }
 install_pkgs_dir()         { "install_pkgs_dir_$distro"         "$@" ; }
 uninstall_pkgs()           { "uninstall_pkgs_$distro"           "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -12,3 +12,8 @@ install_pkgs_dir_ubuntu()         { install_pkgs_dir_deb          "$@" ; }
 uninstall_pkgs_ubuntu()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_ubuntu()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_ubuntu()    { test_kernel_pkgs_func_default "$@" ; }
+
+get_dist_releases_ubuntu()
+{
+    echo "xenial"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -5,6 +5,7 @@
 
 dist_init_container_ubuntu()      { dist_init_container_deb       "$@" ; }
 pkg_files_to_kernel_dirs_ubuntu() { pkg_files_to_kernel_dirs_deb  "$@" ; }
+pkg_files_to_dependencies_ubuntu() { pkg_files_to_dependencies_deb "$@" ; }
 pkg_files_to_names_ubuntu()       { pkg_files_to_names_deb        "$@" ; }
 install_pkgs_ubuntu()             { install_pkgs_deb              "$@" ; }
 install_pkgs_dir_ubuntu()         { install_pkgs_dir_deb          "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -5,7 +5,6 @@
 
 dist_init_container_ubuntu()      { dist_init_container_deb       "$@" ; }
 pkg_files_to_kernel_dirs_ubuntu() { pkg_files_to_kernel_dirs_deb  "$@" ; }
-pkg_files_to_contents_ubuntu()    { pkg_files_to_contents_deb     "$@" ; }
 pkg_files_to_names_ubuntu()       { pkg_files_to_names_deb        "$@" ; }
 install_pkgs_ubuntu()             { install_pkgs_deb              "$@" ; }
 install_pkgs_dir_ubuntu()         { install_pkgs_dir_deb          "$@" ; }

--- a/pwx_test_kernel_pkgs/install.sh
+++ b/pwx_test_kernel_pkgs/install.sh
@@ -16,8 +16,8 @@ install_scripts() {
     done
 }
 
-apt-get install --yes --quiet rpm
-# Needed for Centos support, for extracting information from .rpm files.
+apt-get install --yes --quiet rpm lxc
+# rpm is needed for Centos support, for extracting information from .rpm files.
 
 mkdir -p "${scriptsdir}" "${bindir}"
 

--- a/pwx_test_kernel_pkgs/install.sh
+++ b/pwx_test_kernel_pkgs/install.sh
@@ -2,8 +2,6 @@
 
 prefix=/usr/local
 scriptsdir=${prefix}/share/portworx-kernel-tester/scripts
-#build_results_dir=/var/lib/portworx-kernel-tester/build-results
-build_results_dir=/home/ftp/build-results
 bindir=${prefix}/bin
 
 set -e
@@ -14,7 +12,6 @@ install_scripts() {
     mkdir -p "$dir"
     for file in "$@" ; do
 	sed -e "s|^scriptsdir=.*\$|scriptsdir=${scriptsdir}|" \
-	    -e "s|^build_results_dir=.*\$|build_results_dir=${build_results_dir}|" \
 	    < "$file" > "$dir/$file"
     done
 }
@@ -22,7 +19,7 @@ install_scripts() {
 apt-get install --yes --quiet rpm
 # Needed for Centos support, for extracting information from .rpm files.
 
-mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}"
+mkdir -p "${scriptsdir}" "${bindir}"
 
 install_scripts "${scriptsdir}" \
 		container_driver.*.sh \

--- a/pwx_test_kernel_pkgs/install.sh
+++ b/pwx_test_kernel_pkgs/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prefix=/usr/local
-scriptsdir=${prefix}/share/portworx-kernel-tester/scripts
+scriptsdir=${prefix}/share/pwx_test_kernel_pkgs/scripts
 bindir=${prefix}/bin
 
 set -e

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -39,7 +39,7 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 
 
     Distribution interface (defined by sourcing
-    /usr/local/share/portworx-kernel-tester/distro_driver.sh ):
+    /usr/local/share/pwx_test_kernel_pkgs/distro_driver.sh ):
 
 	The distribution interface uses the $distribution shell global
 	variable to select the distribution type.  Currently, "ubuntu",
@@ -83,7 +83,7 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 
 
     Container interface (defined by sourcing
-    /usr/local/share/portworx-kernel-tester/container_driver.sh ):
+    /usr/local/share/pwx_test_kernel_pkgs/container_driver.sh ):
 
 	The container interface uses the $container_system shell global
 	variable to select the container type.  Currently "docker" is the
@@ -120,5 +120,5 @@ Directories on host:
 
 	/var/lib/pwx-mirror	- Contains crontab.txt
 
-	/usr/local/share/portworx-kernel-tester/scripts
+	/usr/local/share/pwx_test_kernel_pkgs/scripts
 		- All script libraries used by portworx-test-kernels-in-mirror

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -18,6 +18,8 @@ Top level scripts, installed in /usr/local/bin:
 		
 		--arch=architecture            [default: amd64]
 		--distribution=dist            [default: ubuntu]
+		--force
+		--release=dist_release         [default: based on distribution]
 		--containers=container_system  [default: docker]
 		--logdir=logdir                [default: based on distribution]
 		--pfxuse=pxfuse_src_dir        [default: download tempoary
@@ -25,7 +27,8 @@ Top level scripts, installed in /usr/local/bin:
 
 	    Description:
 
-		If logdir/done exists, then do nothing.
+		If logdir/done exists and "--force" was not specified,
+		then do nothing.
 
 		Otherwise, based on values of distribution and
 		container_system, test that the contents of
@@ -45,6 +48,12 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 	variable to select the distribution type.  Currently, "ubuntu",
 	"debian" and "centos" are supported.  Every shell function func
 	listed below is just a wrapper that invokes func_$distribution.
+
+	dist_releases      -       Print a list of available releases
+				   (e.g., "jessie", "stretch" for Debian),
+				   in the order in which they should be
+				   tried.  The first one is used as the
+				   default by init_container drivers.
 
 	dist_init_container	-  Install any needed initial
 				   packages in the initial container.
@@ -98,14 +107,17 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 	function takes an argument that is the function to be called
 	to do the distrbitution-specific initialization of the container.
 
-	start_containter init_command [args...]
+	start_containter [--release=dist_release] init_command [args...]
 			 	  Makes sure a container
 				  is available for in_container.  Uses the
 				  the $distribution shell variables to which
 				  container template to use.  If a new
 				  container had to be created, invoke
 				  init_command [args...] to do the
-				  distribution-specific initialization
+				  distribution-specific initialization.
+				  If "--release=dist_release" is specified,
+				  use that release of the Linux distribution
+				  instead of the default.
 
 	in_container shell_command - Run the shell command in the container.
 		     		   standard input, standard output, standard

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -119,7 +119,6 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 Directories on host:
 
 	/var/lib/pwx-mirror	- Contains crontab.txt
-	/var/lib/portworx-kernel-tester/build-results
 
 	/usr/local/share/portworx-kernel-tester/scripts
 		- All script libraries used by portworx-test-kernels-in-mirror

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -70,7 +70,7 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 				  "apt-get update" or "yum update".
 				  Perhaps unnecessary.
 
-	test_kernel_pkgs_func container_tmpdir results_logdir
+	test_kernel_pkgs_func pxfuse_source_dir results_logdir
 			       - This is the main function of
 				  ./test_kernel_pkgs.  There is
 				  a default version of this function,

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs.sh
@@ -39,7 +39,6 @@ if [[ $# -lt 1 ]] ; then
 fi
 
 local_tmp_dir=/tmp/test-kernels.ubuntu.$$
-remote_tmp_dir=/tmp/test-portworx-kernels
 
 prepare_pxfuse_dir() {
     trap exit_handler EXIT
@@ -50,6 +49,7 @@ prepare_pxfuse_dir() {
 	 git clone https://github.com/portworx/px-fuse.git )
 
 	pxfuse_dir="$local_tmp_dir/px-fuse"
+	# ^^^^^^^ Global variable.
     fi
 }
 
@@ -57,7 +57,7 @@ main() {
     local result
     start_container dist_init_container
 
-    test_kernel_pkgs_func "$remote_tmp_dir" "$logdir" "$@"
+    test_kernel_pkgs_func "$pxfuse_dir" "$logdir" "$@"
     result=$?
 
     stop_container

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs.sh
@@ -13,7 +13,9 @@ usage() {
 
 arch=amd64
 distro=ubuntu
+distro_releases=""
 container_system=docker
+force=false
 logdir=$PWD
 
 exit_handler() {
@@ -25,6 +27,8 @@ while [[ $# -gt 0 ]] ; do
 	--arch=* ) arch=${1#--arch=} ;;
 	--containers=* ) container_system=${1#--containers=} ;;
 	--distribution=* ) distro=${1#--distribution=} ;;
+	--force ) force=true ;;
+	--releases=* ) distro_release=${1#--releases=} ;;
 	--logdir=* ) logdir=${1#--logdir=} ;;
 	--pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
 	--* ) usage >&2 ; exit 1 ;;
@@ -53,16 +57,36 @@ prepare_pxfuse_dir() {
     fi
 }
 
-main() {
-    local result
-    start_container dist_init_container
+test_kernel_pkgs() {
+    local result release releases
 
-    test_kernel_pkgs_func "$pxfuse_dir" "$logdir" "$@"
-    result=$?
+    if [[ -e "$logdir/done" ]] && ! $force ; then
+	echo "test_kernel_pkgs_func_default: $logdir/done exists.  Skipping."
+	return 0
+    fi
 
-    stop_container
+    if [[ -n "$distro_releases" ]] ; then
+	releases=$(echo "$distro_releases" | sed 's/,/ /g')
+    else
+	releases=$(get_dist_releases)
+    fi
+    mkdir -p "$logdir"
+    for release in $releases ; do
+	echo "test_kernel_pkgs: Attempting to test kernel package(s) on distribution $distro, release $release."
+
+	start_container --release="$release" dist_init_container
+
+	test_kernel_pkgs_func "$pxfuse_dir" "$logdir" "$@"
+	result=$?
+
+	stop_container
+	if [[ $result = 0 ]] ; then
+	    break
+	fi
+	force="--force"
+    done > "$logdir/build.log" 2>&1
     return $result
 }
 
 prepare_pxfuse_dir
-main "$@"
+test_kernel_pkgs "$@"

--- a/pwx_test_kernel_pkgs/self-test.debian.sh
+++ b/pwx_test_kernel_pkgs/self-test.debian.sh
@@ -6,7 +6,7 @@
 pxfuse_dir=/home/ubuntu/git/px-fuse
 
 if [ ! -e "$pxfuse_dir" ] ; then
-    cd ${pxfuse_dir%/*} && git clone https://github.com/portworx/px-fuse.git
+    ( cd ${pxfuse_dir%/*} && git clone https://github.com/portworx/px-fuse.git )
 fi
 
 logdir=/tmp/self-test.debian.logdir

--- a/pwx_test_kernel_pkgs/self-test.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/self-test.ubuntu.sh
@@ -6,7 +6,7 @@
 pxfuse_dir=/home/ubuntu/git/px-fuse
 
 if [ ! -e "$pxfuse_dir" ] ; then
-    cd ${pxfuse_dir%/*} && git clone https://github.com/portworx/px-fuse.git
+    ( cd ${pxfuse_dir%/*} && git clone https://github.com/portworx/px-fuse.git )
 fi
 
 logdir=/tmp/self-test.ubuntu.logdir

--- a/pwx_test_kernel_pkgs/self-test.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/self-test.ubuntu.sh
@@ -9,7 +9,7 @@ if [ ! -e "$pxfuse_dir" ] ; then
     cd ${pxfuse_dir%/*} && git clone https://github.com/portworx/px-fuse.git
 fi
 
-logdir=/var/lib/pwx_test_kernel_pkgs/build-results/pxfuse-f90140c0e14979943e34d1b2fdcb0656/ubuntu//v3.13.11-ckt35-trusty/linux-headers-3.13.11-031311ckt35-generic_3.13.11-031311ckt35.201602161330_amd64
+logdir=/tmp/self-test.ubuntu.logdir
 
 rm -f ${logdir}/done
 

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -21,7 +21,7 @@ install_scripts() {
 apt-get install --yes --quiet rpm
 # Needed for Centos support, for extracting information from .rpm files.
 
-mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}"
+mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}/pxfuse/by-checksum"
 
 install_scripts "${scriptsdir}" \
 		mirror_walk_driver.*.sh \

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -4,7 +4,7 @@ scriptsdir=$PWD
 
 log_file=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 
-exec > "$log_file" 2>&1
+exec > "$log_file" 2>&1 < /dev/null
 
 result=0
 for dist in centos debian fedora ubuntu ; do

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -7,7 +7,7 @@ log_file=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 exec > "$log_file" 2>&1
 
 result=0
-for distribution in centos debian ubuntu ; do
+for dist in centos debian fedora ubuntu ; do
     if ! pwx_test_kernels_in_mirror.sh --containers=lxc --distribution="$dist" ; then
 	result=$?
     fi

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -2,9 +2,9 @@
 
 scriptsdir=$PWD
 
-logdir=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
+log_file=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
 
-exec > "$logdir" 2>&1
+exec > "$log_file" 2>&1
 
 result=0
 for distribution in centos debian ubuntu ; do

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror.sh
@@ -32,7 +32,7 @@ exit_handler() {
 distro=ubuntu
 arch=amd64
 container_system=docker
-logdir="$build_results_dir"
+logdir="$build_results_dir/pxfuse/by-checksum"
 pxfuse_dir=""
 command=pwx_test_kernel_pkgs.sh
 mirror_top=/home/ftp/mirrors

--- a/pwx_test_kernels_in_mirror/pwx_update_pxfuse_by_date.sh
+++ b/pwx_test_kernels_in_mirror/pwx_update_pxfuse_by_date.sh
@@ -7,11 +7,14 @@ cd "$datedir" || exit $?
 
 for dir in ../by-checksum/*/ ; do
     dir_no_slash=${dir%/}
-    prefix=$( (TZ='' stat --format=%y "$dir_no_slash") | sed 's/ +0000$//;s/ /_/g' )
-    suffix=${dir_no_slash#../}
-    ln -s "$dir" "${prefix}-${suffix}"
+
+    prefix=$( (TZ='' stat --format=%y "$dir_no_slash") |
+	      sed 's/ +0000$//;s/ /_/g' )
+
+    suffix=${dir_no_slash#../by-checksum/}
+    ln -s "$dir_no_slash" "${prefix}-${suffix}"
 done
 
 latest=$(ls -1dtr ../by-checksum/*/ | tail -1)
 rm -f latest
-ln -s "$latest" latest
+ln -s "${latest%/}" latest

--- a/pwx_test_kernels_in_mirror/pwx_update_pxfuse_by_date.sh
+++ b/pwx_test_kernels_in_mirror/pwx_update_pxfuse_by_date.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 
-datedir=/home/ftp/build-results/pxfuse.by-date
+datedir=/home/ftp/build-results/pxfuse/by-date
 rm -rf "$datedir"
 mkdir -p "$datedir"
 cd "$datedir" || exit $?
 
-for dir in ../pxfuse-*/ ; do
+for dir in ../by-checksum/*/ ; do
     dir_no_slash=${dir%/}
     prefix=$( (TZ='' stat --format=%y "$dir_no_slash") | sed 's/ +0000$//;s/ /_/g' )
     suffix=${dir_no_slash#../}
     ln -s "$dir" "${prefix}-${suffix}"
 done
+
+latest=$(ls -1dtr ../by-checksum/*/ | tail -1)
+rm -f latest
+ln -s "$latest" latest


### PR DESCRIPTION
The changes alter the px.ko compilation test to build with CC="gcc -fno-pie" to avoid dependencies on custom versions of the compiler.  It also now attempts to install dependencies of the packages being installed.

These changes may end up being insufficient.  I may turn out to be necessary to use different containers for different releases of the distributions, at least for Debian, and to try to detect which release a package is intended to support, which is not obvious from directory tree or file naming conventions on snapshot.debian.org.
