### PR TITLE
Possible fix for leaving header files in Ubuntu containers, other minor changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,3 +10,4 @@
 
 5. Maybe deal with kernel source-only RPM's on vault.centos.org.  Apparently the generated kernel header RPM's are not archived.  Maybe we should rebuild all of these from source.
 
+6. Why is Debian Jessie container, and perhaps others, accumulating kernel headerws that are not being removed?

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -2,8 +2,11 @@
 
 scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
 logdir=${scriptsdir}/logs
 logfile=${logdir}/$(date +%Y%m%d.%H:%M:%S).log
+
+error_code=0
 
 copy_link_tree_remove_index_html()
 {
@@ -14,11 +17,13 @@ copy_link_tree_remove_index_html()
     symlinks -d "${to}"
 
     cp --symbolic-link --recursive --remove-destination "$from/." "$to"
+    save_error
 
     find "$to" -name index.html -print0 | xargs --null -- rm -f
     find "$to" -type d | sort -r | xargs rmdir 2> /dev/null || true
 
     symlinks -cs "$to"
+    save_error
 }
 
 run_all_verb_scripts()
@@ -51,3 +56,6 @@ run_all_test_scripts()
 mkdir -p "$logdir"
 
 ( run_all_mirror_scripts ; run_all_test_scripts ) > "$logfile" 2>&1 < /dev/null
+save_error
+
+exit $error_code

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+# ^^ requires bash because save_error() calls bash_stack_trace,
+# which uses bash-specific command "caller".
 
 #arch=i386
 arch=x86_64
@@ -11,6 +13,8 @@ mkdir -p ${mirrordir}
 
 # TIMESTAMPING=--timestamping
 TIMESTAMPING='--no-clobber --no-use-server-timestamps'
+
+error_code=0
 
 versions_above_3_9 () {
     egrep '^v(4|3\.[1-9][0-9]).*/$'
@@ -32,6 +36,8 @@ mirror_el_repo() {
 	 --accept-regex='.*/(index.html)?$' \
 	 ${top_url}
 
+    save_error
+
     for dir in ${top_dir}/*/${rpm_arch}/RPMS/ ; do
 	echo ''
 	extract_subdirs < $dir/index.html |
@@ -40,6 +46,8 @@ mirror_el_repo() {
     done |
 	xargs -- wget --quiet --no-parent ${TIMESTAMPING} \
 	      --protocol-directories --force-directories
+
+    save_error
 }
 
 mirror_mirror_centos_org() {
@@ -61,6 +69,8 @@ mirror_mirror_centos_org() {
     # version might work.
     #
     # --accept-regex="/(index.html)|(kernel-(.*-)?headers-${above_3_9_regexp}(.*-.*-.*)?\..*\.rpm)"
+
+    save_error
 }
 
 
@@ -70,4 +80,9 @@ mirror_mirror_centos_org() {
 
 # mirror_vault_centos_org
 mirror_mirror_centos_org
+save_error
+
 mirror_el_repo
+save_error
+
+exit $error_code

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -41,7 +41,7 @@ mirror_el_repo() {
     for dir in ${top_dir}/*/${rpm_arch}/RPMS/ ; do
 	echo ''
 	extract_subdirs < $dir/index.html |
-	    egrep "^kernel-.*(headers|devel)-.*.${rpm_arch}.rpm$" |
+	    egrep "^kernel-.*devel-.*.${rpm_arch}.rpm$" |
 	    subdirs_to_urls http://${dir#http/}
     done |
 	xargs -- wget --quiet --no-parent ${TIMESTAMPING} \
@@ -62,7 +62,7 @@ mirror_mirror_centos_org() {
 	sed "s|^|${top_url}|;s|\$|/os/x86_64/Packages/|" |
 	xargs wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive --level=1 \
-	 --accept-regex="/(index.html)|(kernel-.*(headers|devel).*\.rpm)"
+	 --accept-regex="/(index.html)|(kernel-.*devel.*\.rpm)"
 
     # FIXME.  The following regular expresion might filter out kernels before
     # 3.10.  It is modified from one that was not working, but maybe this

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -38,7 +38,7 @@ mirror_el_repo() {
 	    egrep "^kernel-.*(headers|devel)-.*.${rpm_arch}.rpm$" |
 	    subdirs_to_urls http://${dir#http/}
     done |
-	xargs -- wget --no-parent ${TIMESTAMPING} \
+	xargs -- wget --quiet --no-parent ${TIMESTAMPING} \
 	      --protocol-directories --force-directories
 }
 

--- a/portworx-mirror-server/mirror-kernels.fedora.sh
+++ b/portworx-mirror-server/mirror-kernels.fedora.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+# ^^ requires bash because save_error() calls bash_stack_trace,
+# which uses bash-specific command "caller".
 
 #arch=i386
 arch=x86_64
@@ -14,17 +16,20 @@ TIMESTAMPING='--no-clobber --no-use-server-timestamps'
 #QUIET=--quiet
 QUIET=
 
+error_code=0
+
 mirror_ncsu_edu() {
     local top_url=http://ftp.linux.ncsu.edu/pub/fedora/linux/releases/
     local top_dir=$(url_to_dir "$top_url")
 
-    wget $(QUIET) --protocol-directories --force-directories \
+    wget ${QUIET} --protocol-directories --force-directories \
 	  "${top_url}"
+    save_error
 
     extract_subdirs < "$top_dir/index.html" |
 	egrep '^[0-9]' |
 	sed "s|^|${top_url}|;s|\$|/Everything/x86_64/os/Packages/k/|" |
-	xargs wget $(QUIET) --no-parent ${TIMESTAMPING} -e robots=off \
+	xargs wget ${QUIET} --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive --level=1 \
 	 --accept-regex="/(index.html)|(kernel-(headers|devel).*\.rpm)"
 
@@ -37,6 +42,9 @@ mirror_ncsu_edu() {
     # version might work.
     #
     # --accept-regex="/(index.html)|(kernel-(.*-)?(headers|devel)-${above_3_9_regexp}(.*-.*-.*)?\..*\.rpm)"
+    save_error
 }
 
 mirror_ncsu_edu
+save_error
+exit $error_code

--- a/portworx-mirror-server/mirror-kernels.fedora.sh
+++ b/portworx-mirror-server/mirror-kernels.fedora.sh
@@ -31,17 +31,17 @@ mirror_ncsu_edu() {
 	sed "s|^|${top_url}|;s|\$|/Everything/x86_64/os/Packages/k/|" |
 	xargs wget ${QUIET} --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive --level=1 \
-	 --accept-regex="/(index.html)|(kernel-(headers|devel).*\.rpm)"
+	 --accept-regex="/(index.html)|(kernel-devel.*\.rpm)"
 
 	 # This version would add kernel-xxx-heades, but currently only
 	 # matches kernel-cross-headers on ftp.linux.ncsu.edu:
-	 # --accept-regex="/(index.html)|(kernel-.*(headers|devel).*\.rpm)"
+	 # --accept-regex="/(index.html)|(kernel-.*devel.*\.rpm)"
 	 
     # FIXME.  The following regular expresion might filter out kernels before
     # 3.10.  It is modified from one that was not working, but maybe this
     # version might work.
     #
-    # --accept-regex="/(index.html)|(kernel-(.*-)?(headers|devel)-${above_3_9_regexp}(.*-.*-.*)?\..*\.rpm)"
+    # --accept-regex="/(index.html)|(kernel-(.*-)?devel-${above_3_9_regexp}(.*-.*-.*)?\..*\.rpm)"
     save_error
 }
 

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -1,5 +1,6 @@
 #
-# This file is intended to be sourced from a shell script.
+# This file is intended to be sourced from a bash script (bash because it
+# currently uses "[[" ... "]]" tests).
 #
 # This file contains common declarations used by mirror-kernels.*.sh.
 
@@ -13,7 +14,7 @@ bash_stack_trace()
     depth=0
     while true ; do
 	set -- $(caller $depth)
-	if [ $# = 0 ] ; then
+	if [[ $# = 0 ]] ; then
 	    break
 	fi
 	line="$1"
@@ -28,7 +29,7 @@ save_error()
 {
     local saved_code=$?
 
-    if [ $saved_code != 0 ] ; then
+    if [[ $saved_code != 0 ]] ; then
 
 	error_code=$saved_code
 

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -6,6 +6,38 @@
 # Used for selecting kernels version 3.10 or later:
 above_3_9_regexp='(3\.[1-9][0-9]|[4-9]|[1-9][0-9])'
 
+bash_stack_trace()
+{
+    # bash_stack_trace uses the bash-specific "caller" command.
+    local depth line func file
+    depth=0
+    while true ; do
+	set -- $(caller $depth)
+	if [ $# = 0 ] ; then
+	    break
+	fi
+	line="$1"
+	func="$2"
+	file="$3"
+	echo "${file}:${line} ${func}"
+	depth=$((depth + 1))
+    done
+}
+
+save_error()
+{
+    local saved_code=$?
+
+    if [ $saved_code != 0 ] ; then
+
+	error_code=$saved_code
+
+	echo "pwx-mirror-util.sh save_error: error in shell script detected.  Trace: " >&2
+	bash_stack_trace >&2
+	echo "" >&2
+    fi
+}
+
 url_to_dir()
 {
     local url="$1"

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -13,6 +13,7 @@ uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }
 dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }
+dist_clean_up_container_fedora()  { dist_clean_up_container_rpm   "$@" ; }
 
 get_dist_releases_centos()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -10,7 +10,7 @@ in_container_flock_deb() {
     local seconds=600
     local lockfile=/var/lib/dpkg/lock
     in_container flock --timeout $seconds -- $lockfile \
-		 flock --unlock $lockfile -- "$@"
+		 flock --unlock -- $lockfile "$@"
 }
 
 dist_init_container_deb() {
@@ -77,3 +77,4 @@ install_pkgs_dir_deb()  {
     # in_container_flock_deb apt-get --fix-broken install --yes --force-yes || true
     # ^^^ Try to install any missing dependencies.
 }
+

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -47,7 +47,12 @@ install_pkgs_deb()      {
 
 # uninstall_pkgs_deb()    { in_container dpkg --remove "$@" ; }
 uninstall_pkgs_deb()    {
-    in_container apt-get remove --quiet --yes --force-yes "$@"
+    local pkg
+    if ! in_container apt-get remove --quiet --yes --force-yes "$@" ; then
+	for pkg in "$@" ; do
+	    in_constainer dpkg --remove --force-remove-reinstreq "$pkg"
+	done
+    fi
 }
 
 pkgs_update_deb()       {

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -71,6 +71,11 @@ pkgs_update_deb()       {
     in_container_flock_deb apt-get update --quiet --yes --force-yes
 }
 
+dist_clean_up_container_deb()
+{
+    in_container_flock_deb sh -c "pkgs=\$( dpkg --list 'linux-headers-*' | awk '\$1 != \"un\" {print \$2;}' | egrep '^linux-headers-' ) ; dpkg --remove \$pkgs"
+}
+
 install_pkgs_dir_deb()  {
     in_container_flock_deb sh -c "dpkg --install --force-all $1/*"
     # in_container_flock_deb apt-get --fix-broken install --quiet --yes --force-yes || true

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -50,7 +50,7 @@ uninstall_pkgs_deb()    {
     local pkg
     if ! in_container apt-get remove --quiet --yes --force-yes "$@" ; then
 	for pkg in "$@" ; do
-	    in_constainer dpkg --remove --force-remove-reinstreq "$pkg"
+	    in_container dpkg --remove --force-remove-reinstreq "$pkg"
 	done
     fi
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -1,11 +1,23 @@
 # This is not a standalone program.  It is a library to be sourced by a shell
 # script.
 
+in_container_flock_deb() {
+    # Do an in_container command, but block for up to five minutes to
+    # acquire (and release) the dpkg lock, to reduce the change of the
+    # command failing due to some automatic dpkg database update running
+    # or something like that.  Something taking the lock broke a few
+    # of he Ubuntu rebuild tests.
+    local seconds=600
+    local lockfile=/var/lib/dpkg/lock
+    in_container flock --timeout $seconds -- $lockfile \
+		 flock --unlock $lockfile -- "$@"
+}
+
 dist_init_container_deb() {
-    in_container apt-get update --quiet --yes
+    in_container_flock_deb apt-get update --quiet --yes
     # ^^^ Skip this for binary reproducibility ??
 
-    in_container apt-get install --quiet --yes \
+    in_container_flock_deb apt-get install --quiet --yes \
 		 autoconf g++ gcc git libelf-dev libssl1.0 make tar
     # TODO?: install gcc-5?
     # Why px-fuse wants git is unclear to me.
@@ -42,26 +54,26 @@ pkg_files_to_dependencies_deb() {
 }
 
 install_pkgs_deb()      {
-    in_container apt-get install --quiet --yes --force-yes "$@"
+    in_container_flock_deb apt-get install --quiet --yes --force-yes "$@"
 }
 
-# uninstall_pkgs_deb()    { in_container dpkg --remove "$@" ; }
+# uninstall_pkgs_deb()    { in_container_flock_deb dpkg --remove "$@" ; }
 uninstall_pkgs_deb()    {
     local pkg
-    if ! in_container apt-get remove --quiet --yes --force-yes "$@" ; then
+    if ! in_container_flock_deb apt-get remove --quiet --yes --force-yes "$@" ; then
 	for pkg in "$@" ; do
-	    in_container dpkg --remove --force-remove-reinstreq "$pkg"
+	    in_container_flock_deb dpkg --remove --force-remove-reinstreq "$pkg"
 	done
     fi
 }
 
 pkgs_update_deb()       {
-    in_container apt-get update --quiet --yes --force-yes
+    in_container_flock_deb apt-get update --quiet --yes --force-yes
 }
 
 install_pkgs_dir_deb()  {
-    in_container sh -c "dpkg --install --force-all $1/*"
-    # in_container apt-get --fix-broken install --quiet --yes --force-yes || true
-    # in_container apt-get --fix-broken install --yes --force-yes || true
+    in_container_flock_deb sh -c "dpkg --install --force-all $1/*"
+    # in_container_flock_deb apt-get --fix-broken install --quiet --yes --force-yes || true
+    # in_container_flock_deb apt-get --fix-broken install --yes --force-yes || true
     # ^^^ Try to install any missing dependencies.
 }

--- a/pwx_test_kernel_pkgs/distro_driver.debian.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.debian.sh
@@ -14,6 +14,7 @@ install_pkgs_dir_debian()         { install_pkgs_dir_deb          "$@" ; }
 uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_debian()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_debian()    { test_kernel_pkgs_func_default "$@" ; }
+dist_clean_up_container_debian()  { dist_clean_up_container_deb   "$@" ; }
 
 get_dist_releases_debian()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -12,6 +12,7 @@ uninstall_pkgs_fedora()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_fedora()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_fedora()    { test_kernel_pkgs_func_default "$@" ; }
 dist_init_container_fedora()      { dist_init_container_rpm       "$@" ; }
+dist_clean_up_container_fedora()  { dist_clean_up_container_rpm   "$@" ; }
 
 get_dist_releases_fedora()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -36,3 +36,4 @@ install_pkgs_dir_rpm() {
 install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
 uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
 pkgs_update_rpm()      { in_container yum --assumeyes --quiet update ; }
+dist_clean_up_container_rpm() { true; }	# No-op for now.

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -20,6 +20,7 @@ install_pkgs_dir()         { "install_pkgs_dir_$distro"         "$@" ; }
 uninstall_pkgs()           { "uninstall_pkgs_$distro"           "$@" ; }
 pkgs_update()              { "pkgs_update_$distro"              "$@" ; }
 test_kernel_pkgs_func()    { "test_kernel_pkgs_func_$distro"    "$@" ; }
+dist_clean_up_container()  { "dist_clean_up_container_$distro"  "$@" ; }
 
 filter_word() {
     # Echo the first word if it does not match any of the subsequent words

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -118,6 +118,7 @@ test_kernel_pkgs_func_default() {
 
     uninstall_pkgs $pkg_names
     in_container rm -rf "$container_tmpdir"
+    dist_cleanup_container
 
     echo "test_kernel_pkgs_func_default: build_exit_code=$result" >&2
     # if [[ "$result" != 0 ]] ; then

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -12,6 +12,7 @@ install_pkgs_dir_ubuntu()         { install_pkgs_dir_deb          "$@" ; }
 uninstall_pkgs_ubuntu()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_ubuntu()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_ubuntu()    { test_kernel_pkgs_func_default "$@" ; }
+dist_clean_up_container_ubuntu()  { dist_clean_up_container_deb   "$@" ; }
 
 get_dist_releases_ubuntu()
 {

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -108,6 +108,9 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 				  after running potentially multiple
 				  tests.
 
+	dist_cleanup_container - Called after test is run to remove
+				 any remaining distribution-specific
+				 residue.
 
     Container interface (defined by sourcing
     /usr/local/share/pwx_test_kernel_pkgs/container_driver.sh ):

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -123,7 +123,7 @@ main()
     else
 	prepare_pxfuse_dir
 	mkdir -p "$logdir"
-	test_kernel_pkgs "$@" > "$logdir/build.log" 2>&1
+	( echo "Command: pwx_test_kernel_pkgs $*" ; test_kernel_pkgs "$@" ) > "$logdir/build.log" 2>&1
     fi
 }
 

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -27,14 +27,16 @@ install_scripts "${scriptsdir}" \
 		mirror_walk_driver.*.sh \
 		mirror_walk_driver.sh \
 		pwx_test_kernels.cron_script.sh \
-		pwx_update_pxfuse_by_date.sh
+		pwx_update_pxfuse_by_date.sh \
+		test_report.sh
 
 install_scripts "${bindir}" pwx_test_kernels_in_mirror
 
 chmod a+x \
       "${bindir}/pwx_test_kernels_in_mirror" \
       "${scriptsdir}/pwx_test_kernels.cron_script.sh" \
-      "${scriptsdir}/pwx_update_pxfuse_by_date.sh"
+      "${scriptsdir}/pwx_update_pxfuse_by_date.sh" \
+      "${scriptsdir}/test_report.sh"
 
 old_crontab=$( ( crontab -u root -l 2> /dev/null ) |
 	      egrep -v pwx_test_kernels.cron_script.sh |

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -14,7 +14,7 @@ get_default_mirror_dirs_centos()
 
 walk_mirror_centos() {
     local mirror_tree="$1"
-    local file rpm_arch return_status
+    local file rpm_arch return_status kernel_regexp
 
     shift 1
 
@@ -25,7 +25,9 @@ walk_mirror_centos() {
     fi
 
     return_status=0
-    find "$mirror_tree" -name "kernel-*headers-*.${rpm_arch}.rpm" -type f -print0 |
+
+    kernel_regexp=".*/kernel-([a-z]+-)?devel-${above_3_9_regexp}[0-9.]*-.*${rpm_arch}.rpm"
+    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f -print0 |
 	while read -r -d $'\0' file ; do
             if ! "$@" "$file" ; then
 		return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -14,8 +14,7 @@ get_default_mirror_dirs_centos()
 
 walk_mirror_centos() {
     local mirror_tree="$1"
-    local file dir base devel_base base_without_kernel middle devel_file
-    local rpm_arch return_status
+    local file rpm_arch return_status
 
     shift 1
 
@@ -28,26 +27,7 @@ walk_mirror_centos() {
     return_status=0
     find "$mirror_tree" -name "kernel-*headers-*.${rpm_arch}.rpm" -type f -print0 |
 	while read -r -d $'\0' file ; do
-	    dir=${file%/*}
-	    base=${file##*/}
-	    base_without_kernel="${base#kernel-}"
-	    middle="${base_without_kernel%headers*}"
-	    devel_base="kernel-${middle}devel-${base#kernel*-headers-}"
-	    devel_file="$dir/$devel_base"
-	    echo "AJR mirror_walk_driver.centos.sh: walk_mirror_centos:" >&2
-	    echo "    dir=$dir" >&2
-	    echo "    base=$base" >&2
-	    echo "    devel_base=$devel_base" >&2
-	    echo "    devel_file=$devel_file" >&2
-	    if ! [[ -e "$devel_file" ]] ; then
-		echo "    devel_file not found" >&2
-		devel_file=""
-	    else
-		echo "    devel_file found" >&2
-	    fi
-	    echo "" >&2
-	    # This assumes devel_file does not have spaces in its name:
-            if ! "$@" "$file" $devel_file ; then
+            if ! "$@" "$file" ; then
 		return_status=$?
 	    fi
 	done

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
@@ -23,7 +23,9 @@ walk_mirror_fedora() {
     fi
 
     return_status=0
-    find "$mirror_tree" -name "kernel-devel-*.${rpm_arch}.rpm" -type f -print0 |
+
+    kernel_regexp=".*/kernel-([a-z]+-)?devel-${above_3_9_regexp}[0-9.]*-.*${rpm_arch}.rpm"
+    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f -print0 |
 	while read -r -d $'\0' file ; do
             if ! "$@" "$file" ; then
 		return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
@@ -12,7 +12,7 @@ get_default_mirror_dirs_fedora()
 
 walk_mirror_fedora() {
     local mirror_tree="$1"
-    local file dir base devel_base devel_file rpm_arch return_status
+    local file rpm_arch return_status
 
     shift 1
 
@@ -23,17 +23,9 @@ walk_mirror_fedora() {
     fi
 
     return_status=0
-    find "$mirror_tree" -name "kernel-headers-*.${rpm_arch}.rpm" -type f -print0 |
+    find "$mirror_tree" -name "kernel-devel-*.${rpm_arch}.rpm" -type f -print0 |
 	while read -r -d $'\0' file ; do
-	    dir=${file%/*}
-	    base=${file##*/}
-	    devel_base="kernel-devel-${base#kernel-headers-}"
-	    devel_file="$dir/$devel_base"
-	    if ! [[ -e "$devel_file" ]] ; then
-		devel_file=""
-	    fi
-	    # This assumes devel_file does not have spaces in its name:
-            if ! "$@" "$file" $devel_file ; then
+            if ! "$@" "$file" ; then
 		return_status=$?
 	    fi
 	done

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -9,6 +9,8 @@
 . $scriptsdir/mirror_walk_driver.centos.sh
 . $scriptsdir/mirror_walk_driver.fedora.sh
 
+# Used for selecting kernels version 3.10 or later.  Used by some drivers.
+above_3_9_regexp='(3\.[1-9][0-9]+|[4-9][0-9]*|[1-9][0-9]+)(\.[.0-9]+[0-9])?'
 
 get_default_mirror_dirs()  { "get_default_mirror_dirs_$distro"  "$@" ; }
 pkg_files_to_names()       { "pkg_files_to_names_$distro"       "$@" ; }

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -29,6 +29,7 @@ for dist in centos debian fedora ubuntu ; do
 done
 
 $scriptsdir/pwx_update_pxfuse_by_date.sh
+$scriptsdir/test_report.sh
 
 echo "pwx_test_kernels.cron_script.sh: result=$result"
 

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd /home/ftp/build-results/pxfuse/by-date/latest || exit $?
+for distribution in */ ; do
+    pass=$( find "$distribution" -name exit_code | xargs egrep -l '^0 ' | wc -l)
+    fail=$( find "$distribution" -name exit_code | xargs egrep -L '^0 ' | wc -l)
+    echo "${distribution%/}: $pass pass, $fail fail."
+done > test-report.txt
+

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -1,9 +1,87 @@
-#!/bin/sh
+#!/bin/bash
+# ^^^^^^^^^ bash because this script uses an associative array..
 
 cd /home/ftp/build-results/pxfuse/by-date/latest || exit $?
-for distribution in */ ; do
-    pass=$( find "$distribution" -name exit_code | xargs egrep -l '^0 ' | wc -l)
-    fail=$( find "$distribution" -name exit_code | xargs egrep -L '^0 ' | wc -l)
-    echo "${distribution%/}: $pass pass, $fail fail."
-done > test-report.txt
 
+output_html_header() {
+    local title="$1"
+cat <<EOF
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+           $title
+        </title>
+    </head>
+<body>
+
+EOF
+}
+
+output_html_tailer() {
+    echo "</body>"
+    echo "</html>"
+}
+
+output_html_link() {
+    local link="$1"
+    echo "<A href=\"${link}\">${link}</A>"
+}
+
+output_html_link_and_note_paragraph() {
+    local link="$1"
+    local note="$2"
+    echo "<P>"
+    output_html_link "$link"
+    echo "($note)"
+    echo "</P>"
+    echo ""
+}
+
+
+mkdir -p test_report
+rm -f test_report/test_report.txt
+
+output_html_header "Portworx kernel testing report" \
+    > test_report/test_report.html
+
+for dir in */ ; do
+    if [[ "$dir" = "test_report/" ]] ; then
+        continue
+    fi
+
+    distribution=${dir%/}
+    out_dir="test_report/$distribution"
+    mkdir -p "$out_dir"
+
+    success_count=$(find "$distribution" -name exit_code -print0 | xargs --null --no-run-if-empty -- egrep -l '^0 ' | wc -l)
+    fail_count=$(find "$distribution" -name exit_code -print0 | xargs --null --no-run-if-empty -- egrep -L '^0 ' | wc -l)
+
+    find "$distribution" -name exit_code | sort --unique |
+        while read filename ; do
+            read exit_code rest < "$filename"
+
+            if [ ".$exit_code" = ".0" ] ; then
+                out_file="${out_dir}/successes.html"
+            else
+                out_file="${out_dir}/failures.html"
+            fi
+            link="../../${filename%/exit_code}"
+	    output_html_link_and_note_paragraph "$link" "$rest" >> "$out_file"
+        done
+    echo "${distribution}: $success_count pass, $fail_count fail." >> test_report/test_report.txt
+
+    echo "
+<P>
+<A href=\"../${distribution}\"> ${distribution}:</A>
+<A href=\"${distribution}/successes.html\"> $success_count pass</A>,
+<A href=\"${distribution}/failures.html\"> $fail_count fail</A>.
+</P>
+" >> test_report/test_report.html
+
+done
+
+cat >> test_report/test_report.html <<EOF
+</body>
+</html>
+EOF

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -14,11 +14,13 @@ cat <<EOF
         </title>
     </head>
 <body>
-
+    <h2>
+        $title
+    </h2>
 EOF
 }
 
-output_html_tailer() {
+output_html_trailer() {
     echo "</body>"
     echo "</html>"
 }
@@ -42,7 +44,9 @@ output_html_link_and_note_paragraph() {
 mkdir -p test_report
 rm -f test_report/test_report.txt
 
-output_html_header "Portworx kernel testing report" \
+what_we_are_doing="building Portworx px.ko kernel module"
+
+output_html_header "Test report for $what_we_are_doing" \
     > test_report/test_report.html
 
 for dir in */ ; do
@@ -57,6 +61,10 @@ for dir in */ ; do
     success_count=$(find "$distribution" -name exit_code -print0 | xargs --null --no-run-if-empty -- egrep -l '^0 ' | wc -l)
     fail_count=$(find "$distribution" -name exit_code -print0 | xargs --null --no-run-if-empty -- egrep -L '^0 ' | wc -l)
 
+    output_html_header "Successes for $what_we_are_doing on $distribution" \
+		       > "${out_dir}/successes.html"
+    output_html_header "Failures for $what_we_are_doing on $distribution" \
+		       > "${out_dir}/failures.html"
     find "$distribution" -name exit_code | sort --unique |
         while read filename ; do
             read exit_code rest < "$filename"
@@ -69,6 +77,9 @@ for dir in */ ; do
             link="../../${filename%/exit_code}"
 	    output_html_link_and_note_paragraph "$link" "$rest" >> "$out_file"
         done
+    output_html_trailer >> "${out_dir}/successes.html"
+    output_html_trailer >> "${out_dir}/failures.html"
+
     echo "${distribution}: $success_count pass, $fail_count fail." >> test_report/test_report.txt
 
     echo "
@@ -81,7 +92,4 @@ for dir in */ ; do
 
 done
 
-cat >> test_report/test_report.html <<EOF
-</body>
-</html>
-EOF
+output_html_trailer >> test_report/test_report.html


### PR DESCRIPTION
The biggest fix in this patch is what I believe should be a fix for a bug where header file packages were not being uninstalled from the Ubuntu containers by the test script.  This resulted in the maximum number of files (currently configured at ~16 million) being reached in the root partition.  Normally, there are only about ~350,000 files in it.

The other important change is a workaround for a a bug where network configuration was often not be completed for the Centos 6 containers.  I still do not know the underlying cause, but this change does "/etc/init.d/network restart" if the default network route is not set within a certain amount of time.

The rest of the changes are minor clean-ups: make the mirror cron script return failure if any wget command failed (although this almost always happens, so the failure returns are still not particularly informative so far), and other clean ups.