### PR TITLE
Remove "--" from calls to the flock program, which does not accept that syntax

### DIFF
--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -9,8 +9,8 @@ in_container_flock_deb() {
     # of he Ubuntu rebuild tests.
     local seconds=600
     local lockfile=/var/lib/dpkg/lock
-    in_container flock --timeout $seconds -- $lockfile \
-		 flock --unlock -- $lockfile "$@"
+    in_container flock --timeout $seconds $lockfile \
+		 flock --unlock $lockfile "$@"
 }
 
 dist_init_container_deb() {
@@ -82,4 +82,3 @@ install_pkgs_dir_deb()  {
     # in_container_flock_deb apt-get --fix-broken install --yes --force-yes || true
     # ^^^ Try to install any missing dependencies.
 }
-


### PR DESCRIPTION
It looks like everything that I submitted since my last pull request was already integrated by the latest merge, except for this important syntax error fix that I had forgotten to commit so here it is.    Sorry for the extra round trip.