### PR TITLE
Add locking for containers and log files to avoid conflicts with simultaneous test runs

### DIFF
--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -36,6 +36,20 @@ on_or_after_linux_3_10_release_date() {
     egrep '^(2013051[1-9]|201305[23]|20130[6-9]|20131|201[4-9]|2[1-9]|[3-9])'
 }
 
+rename_bad_deb_files() {
+    local file
+    # FIXME?  Perhaps in the future, it would be better to maintain
+    # a list of files that have already been checked and only check new
+    # additions most of the time.  Better yet would be to have wget
+    # download files to a temporary name, and only move them into place
+    # after verifying them.
+    find "$@" -name '*.deb' -type f -print0 |
+	while read -r -d $'\0' file ; do
+	    if ! dpkg --contents "$file" > /dev/null 2>&1 ; then
+		mv --force "$file" "${file}.corrupt"
+	done
+}
+
 list_kernel_dir_urls() {
     cat "${top_dir}"/index.html\?year=* |
         extract_subdirs |
@@ -262,6 +276,7 @@ mirror_pkg_files() {
     save_error
 }
 
+rename_bad_deb_files "$top_dir"
 mirror_top_level_directories
 save_error
 

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -118,7 +118,7 @@ test_kernel_pkgs_func_default() {
 
     uninstall_pkgs $pkg_names
     in_container rm -rf "$container_tmpdir"
-    dist_cleanup_container
+    dist_clean_up_container
 
     echo "test_kernel_pkgs_func_default: build_exit_code=$result" >&2
     # if [[ "$result" != 0 ]] ; then

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -35,7 +35,6 @@ filter_word() {
     echo "$first"
 }
 
-# test_kernel_pkgs_func_default also sets the global variable ran_test
 test_kernel_pkgs_func_default() {
     local container_tmpdir result_logdir
     local result filename real dirname basename headers_dir
@@ -113,7 +112,7 @@ test_kernel_pkgs_func_default() {
 	    in_container tar -C "${container_tmpdir}/pxfuse_dir" -c px.ko |
 		tar -C "${result_logdir}" -xpv
 	fi # result = 0
-	ran_test=true	# Global variable
+	touch "${result_logdir}/ran_test"
     fi # result = 0
 
     uninstall_pkgs $pkg_names

--- a/pwx_test_kernel_pkgs/install.sh
+++ b/pwx_test_kernel_pkgs/install.sh
@@ -25,10 +25,10 @@ install_scripts "${scriptsdir}" \
 		container_driver.*.sh \
 		container_driver.sh \
 		distro_driver.*.sh \
-		distro_driver.sh
+		distro_driver.sh \
+		pwx_test_kernel_pkgs_one_container.sh
 
 install_scripts "${bindir}" pwx_test_kernel_pkgs
 
-chmod a+x "${bindir}/pwx_test_kernel_pkgs"
-
-
+chmod a+x "${bindir}/pwx_test_kernel_pkgs" \
+    "${scriptsdir}/pwx_test_kernel_pkgs_one_container.sh"

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -108,9 +108,9 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 				  after running potentially multiple
 				  tests.
 
-	dist_cleanup_container - Called after test is run to remove
-				 any remaining distribution-specific
-				 residue.
+	dist_clean_up_container - Called after test is run to remove
+				  any remaining distribution-specific
+				  residue.
 
     Container interface (defined by sourcing
     /usr/local/share/pwx_test_kernel_pkgs/container_driver.sh ):

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -45,9 +45,9 @@ while [[ $# -gt 0 ]] ; do
 	--force ) force=true ;;
 	--help ) usage ; exit 0 ;;
 	--leave-containers-running ) leave_containers_running=true ;;
-	--releases=* ) distro_release=${1#--releases=} ;;
 	--logdir=* ) logdir=${1#--logdir=} ;;
 	--pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
+	--releases=* ) distro_release=${1#--releases=} ;;
 	--* ) usage >&2 ; exit 1 ;;
 	* ) break ;;
     esac

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -98,7 +98,7 @@ test_kernel_pkgs() {
 	for release in $releases ; do
 	    lockfile="$lockdir/container_${container_system}_${distro}_${release}"
 	    touch -f "$lockfile"
-	    flock --exclusive "$lockfile" \
+	    flock --exclusive --close "$lockfile" \
 		  $scriptsdir/pwx_test_kernel_pkgs_one_container.sh \
 			"--pxfuse=$pxfuse_dir" \
 			"--release=$release" \

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -28,35 +28,41 @@ arch=amd64
 distro=ubuntu
 distro_releases=""
 container_system=lxc
-leave_containers_running=false
 force=false
 logdir=$PWD
+lockdir=/var/lock/pwx_test_kernel_pkgs
+pxfuse_dir=
 
 exit_handler() {
     rm -rf "$local_tmp_dir"
 }
 
-while [[ $# -gt 0 ]] ; do
-    case "$1" in
-	--arch=* ) arch=${1#--arch=} ;;
-	--containers=* ) container_system=${1#--containers=} ;;
-	--distribution=* ) distro=${1#--distribution=} ;;
-	--force ) force=true ;;
-	--help ) usage ; exit 0 ;;
-	--leave-containers-running ) leave_containers_running=true ;;
-	--logdir=* ) logdir=${1#--logdir=} ;;
-	--pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
-	--releases=* ) distro_release=${1#--releases=} ;;
-	--* ) usage >&2 ; exit 1 ;;
-	* ) break ;;
-    esac
-    shift
-done
+# Use a function to parse main argument to avoid modifying them.
+parse_args() {
+    while [[ $# -gt 0 ]] ; do
+	case "$1" in
+	    --arch=* ) arch=${1#--arch=} ;;
+	    --containers=* ) container_system=${1#--containers=} ;;
+	    --distribution=* ) distro=${1#--distribution=} ;;
+	    --force ) force=true ;;
+	    --help ) usage ; exit 0 ;;
+	    --leave-containers-running ) true ;;
+	    --logdir=* ) logdir=${1#--logdir=} ;;
+	    --pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
+	    --releases=* ) distro_release=${1#--releases=} ;;
+	    --* ) usage >&2 ; exit 1 ;;
+	    * ) break ;;
+	esac
+	shift
+    done
 
-if [[ $# -lt 1 ]] ; then
-    usage >&2
-    exit 1
-fi
+    if [[ $# -lt 1 ]] ; then
+	usage >&2
+	exit 1
+    fi
+}
+
+parse_args "$@"
 
 local_tmp_dir=/tmp/test-kernels.ubuntu.$$
 
@@ -74,9 +80,9 @@ prepare_pxfuse_dir() {
 }
 
 test_kernel_pkgs() {
-    local result release releases local make_args
+    local result release releases local make_args lockfile
 
-    ran_test=false	# global variable
+    echo "Command: pwx_test_kernel_pkgs $*"
 
     if [[ -n "$distro_releases" ]] ; then
 	releases=$(echo "$distro_releases" | sed 's/,/ /g')
@@ -84,20 +90,23 @@ test_kernel_pkgs() {
 	releases=$(get_dist_releases)
     fi
 
+    mkdir -p "$lockdir"
+
     result=1 # in case one of the loops should be empty for some reason.
 
     for make_args in "" "CC=\"gcc -fno-pie\"" ; do
 	for release in $releases ; do
-	    echo "test_kernel_pkgs: Attempting to test kernel package(s) on distribution $distro, release $release, make_args=$make_args."
+	    lockfile="$lockdir/container_${container_system}_${distro}_${release}"
+	    touch -f "$lockfile"
+	    flock --exclusive "$lockfile" \
+		  $scriptsdir/pwx_test_kernel_pkgs_one_container.sh \
+			"--pxfuse=$pxfuse_dir" \
+			"--release=$release" \
+			"--make-args=$make_args" \
+			$@
 
-	    start_container --release="$release" dist_init_container
-
-	    test_kernel_pkgs_func "$pxfuse_dir" "$logdir" "$make_args" "$@"
 	    result=$?
 
-	    if ! $leave_containers_running ; then
-		stop_container
-	    fi
 	    if [[ $result = 0 ]] ; then
 		break
 	    fi
@@ -107,11 +116,7 @@ test_kernel_pkgs() {
 	fi
     done
     echo "$result $distro $release make_args=$make_args" > "$logdir/exit_code"
-    if $ran_test ; then
-	touch "$logdir/done"
-	# ^^ We have a "done" file in addition to an "exit_code" file, because
-	# creating the empty "done" file is atomic.
-    fi
+    mv "$logdir/ran_test" "$logdir/done" 2> /dev/null
     return $result
 }
 
@@ -122,7 +127,8 @@ main()
     else
 	prepare_pxfuse_dir
 	mkdir -p "$logdir"
-	( echo "Command: pwx_test_kernel_pkgs $*" ; test_kernel_pkgs "$@" ) > "$logdir/build.log" 2>&1
+	rm -f "$logdir/ran_test"
+	test_kernel_pkgs "$@" > "$logdir/build.log" 2>&1
     fi
 }
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -16,8 +16,7 @@ Usage: pwx_test_kernel_pkgs [options] pkg_files...
 	--logdir=logdir                [default: based on distribution]
 	--pfxuse=pxfuse_src_dir        [default: download tempoary
 				        directory from github]
-	--release=dist_release         [default: based on distribution]
-
+	--releases=dist_releases       [default: based on distribution]
 EOF
 }
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# ^^^^^^^^^ bash because it uses "[["
+
+scriptsdir=$PWD
+
+usage() {
+    cat <<EOF
+Usage: pwx_test_kernel_pkgs [options] pkg_files...
+    options:
+	--arch=architecture            [default: amd64]
+	--containers=container_system  [default: docker]
+	--distribution=dist            [default: ubuntu]
+	--force
+        --help
+	--leave-containers-running
+	--logdir=logdir                [default: based on distribution]
+	--pfxuse=pxfuse_src_dir        [default: download tempoary
+				        directory from github]
+	--release=dist_releaes         Which releaes of the OS distribution
+                                       to use.  Mandatory.
+	--releases=dist_releases       Ignored
+EOF
+}
+
+
+. ${scriptsdir}/container_driver.sh
+. ${scriptsdir}/distro_driver.sh
+
+arch=amd64
+distro=ubuntu
+distro_release=""
+container_system=lxc
+leave_containers_running=false
+make_args=""
+force=false
+logdir=$PWD
+pxfuse_dir=""
+
+exit_handler() {
+    rm -rf "$local_tmp_dir"
+}
+
+while [[ $# -gt 0 ]] ; do
+    case "$1" in
+	--arch=* ) arch=${1#--arch=} ;;
+	--containers=* ) container_system=${1#--containers=} ;;
+	--distribution=* ) distro=${1#--distribution=} ;;
+	--force ) force=true ;;
+	--help ) usage ; exit 0 ;;
+	--leave-containers-running ) leave_containers_running=true ;;
+	--logdir=* ) logdir=${1#--logdir=} ;;
+	--make-args=* ) make_args="${1#--make-args=}" ;;
+	--pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
+	--release=* ) distro_release=${1#--release=} ;;
+	--releases=* ) true ;;	# Ignore
+	--* ) usage >&2 ; exit 1 ;;
+	* ) break ;;
+    esac
+    shift
+done
+
+if [[ $# -lt 1 ]] ; then
+    usage >&2
+    exit 1
+fi
+
+if [[ -z "$distro_release" ]] ; then
+    echo "$0: \"--release=...\" must be specified." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ -z "$pxfuse_dir" ]] ; then
+    echo "$0: \"--pxfuse=...\" must be specified." >&2
+    usage >&2
+    exit 1
+fi
+
+local_tmp_dir=/tmp/test-kernels.ubuntu.$$
+
+test_kernel_pkgs() {
+    local result local
+    local release="$distro_release"
+
+    echo "Command: pwx_test_kernel_pkgs_one_container.sh $*"
+
+    echo "test_kernel_pkgs: Attempting to test kernel package(s) on distribution $distro, release $release, make_args=$make_args."
+
+    start_container --release="$release" dist_init_container
+
+    test_kernel_pkgs_func "$pxfuse_dir" "$logdir" "$make_args" "$@"
+    result=$?
+
+    if ! $leave_containers_running ; then
+	stop_container
+    fi
+
+    return $result
+}
+
+test_kernel_pkgs "$@"

--- a/pwx_test_kernels_in_mirror/programming-interface.txt
+++ b/pwx_test_kernels_in_mirror/programming-interface.txt
@@ -18,7 +18,7 @@ Top level scripts, installed in /usr/local/bin:
 		--mirror-top=mirror_top_dir
 		--pfxuse=pxfuse_src_dir        [default: download tempoary
 
-		Descent into all subdirectories of mirror_dirs, finding
+		Descend into all subdirectories of mirror_dirs, finding
 		kernel head packages that should be grouped together,
 		and pass each group of packages to subcommand (usually
 		pwx_test_kernel_pkgs) with the arguments --distribution,

--- a/pwx_test_kernels_in_mirror/programming-interface.txt
+++ b/pwx_test_kernels_in_mirror/programming-interface.txt
@@ -26,7 +26,10 @@ Top level scripts, installed in /usr/local/bin:
 		additional arguments passwd with "--command-args" (although it
 		is also possible to pass arguments by passing a
 		"--command=..." value that includes spaces followed
-		by arguments).
+		by arguments).  pwx_test_kernels_in_mirror only runs the
+		subcommand if it succeeds in making a nonblocking request
+		to flock the log directory.  The lock is held while the
+		subcommand runs.
 
 		The value of logdir passed to the command is changed to
 		logdir/pxfuse-checksum-$CHECKSUM/distro/mirror_dir/subdir/pkg

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
@@ -90,7 +90,7 @@ mirror_callback() {
     local mirror_dir="$1"
     local log_subdir="$2"
     local pkg1="$3"
-    local pkg_subdir
+    local pkg_subdir command_logdir result
 
     if [[ -n "$mirror_top" ]] ; then
 	pkg_subdir=${pkg1#$mirror_top}
@@ -100,12 +100,15 @@ mirror_callback() {
 
     shift 2
 
-    $command $command_args \
-	"--arch=$arch" \
-	"--distribution=$distro" \
-	"--logdir=${log_subdir}/${pkg_subdir}" \
-	"--pxfuse=$pxfuse_dir" \
-	"$@"
+    command_logdir="${log_subdir}/${pkg_subdir}"
+    mkdir -p "$command_logdir"
+    flock --close --exclusive --nonblock "$command_logdir" \
+	  $command $command_args \
+		"--arch=$arch" \
+		"--distribution=$distro" \
+		"--logdir=${log_subdir}/${pkg_subdir}" \
+		"--pxfuse=$pxfuse_dir" \
+		"$@"
 }
 
 prepare_pxfuse_dir


### PR DESCRIPTION
These changes use the flock program (which uses the flock system call) to avoid conflicts if multiple instances of pwx_test_kernels_in_mirror are running.  This can happen, for example, if the one runs a test run while the nightly test runs from the cron script are in progress.  There are now three places where flock locking is used by pwx_test_kernel_pkgs:

1. A non-blocking lock on log file directories.  If a lock cannot be take, the test is skipped.  Presumbly, the assumption that the test if being run by another script, so the results will soon be available anyhow.  If you want to run tests of a different pxfuse directory, you will normally use a different log directory tree too.

2. A block lock on each container that is held for the entire invocation of the test within that container.  That way, even different tests can safely share containers.  TODO?: An alternative to this might be to create additional containers on lock failure.  In order to give the lockf program a separate program to invoke with lock held /usr/local/share/pwx_test_kernel_pkgs_one_container.sh has been broken out from /usr/local/bin/pwx_test_kernel_pkgs.

3. Within the Debian and Ubuntu containers, lockf on /var/lock/dpkg/lock is used to protect against contention from a periodic process that updates the package database.  This locking is not new for these changes.

This changes also have an important typographical correction where a shell function to clean up a container after a test run was not being called, which I believe was responsible for the reappearance of the bug where Debian and Ubuntu containers were accumulated huge numbers of kernel header files (because kernel header packages were not being removed).