### PR TITLE
Deal with truncated package files, abort earlier to avoid follow-on problems, guess operating systems for faster testing

### DIFF
--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -63,8 +63,7 @@ mirror_mirror_centos_org() {
 
     rename_bad_rpm_files "$top_dir"
 
-    wget --quiet --protocol-directories --force-directories \
-	  "${top_url}"
+    wget --quiet --protocol-directories --force-directories "${top_url}"
 
     extract_subdirs < "$top_dir/index.html" |
 	egrep '^[1-9][0-9]*\.[0-9]+' |

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -33,7 +33,12 @@ mirror_el_repo() {
 
     rename_bad_rpm_files "$top_dir"
 
-    wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
+    # For now, do not include "--no-clobber" in this top level wget.
+    # Pull new index.html files every time.  Otherwise, the files do
+    # not get updated.  FIXME: Confirm that  timestamps are not
+    # supported by the elrepo web server.
+    #
+    wget --quiet --no-parent -e robots=off \
 	 --protocol-directories --force-directories --recursive \
 	 --accept-regex='.*/(index.html)?$' \
 	 ${top_url}

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -31,6 +31,8 @@ mirror_el_repo() {
 	* ) rpm_arch="$arch" ;;
     esac
 
+    rename_bad_rpm_files "$top_dir"
+
     wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive \
 	 --accept-regex='.*/(index.html)?$' \
@@ -53,6 +55,8 @@ mirror_el_repo() {
 mirror_mirror_centos_org() {
     local top_url=http://mirror.centos.org/centos/
     local top_dir=$(url_to_dir "$top_url")
+
+    rename_bad_rpm_files "$top_dir"
 
     wget --quiet --protocol-directories --force-directories \
 	  "${top_url}"

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -36,20 +36,6 @@ on_or_after_linux_3_10_release_date() {
     egrep '^(2013051[1-9]|201305[23]|20130[6-9]|20131|201[4-9]|2[1-9]|[3-9])'
 }
 
-rename_bad_deb_files() {
-    local file
-    # FIXME?  Perhaps in the future, it would be better to maintain
-    # a list of files that have already been checked and only check new
-    # additions most of the time.  Better yet would be to have wget
-    # download files to a temporary name, and only move them into place
-    # after verifying them.
-    find "$@" -name '*.deb' -type f -print0 |
-	while read -r -d $'\0' file ; do
-	    if ! dpkg --contents "$file" > /dev/null 2>&1 ; then
-		mv --force "$file" "${file}.corrupt"
-	done
-}
-
 list_kernel_dir_urls() {
     cat "${top_dir}"/index.html\?year=* |
         extract_subdirs |

--- a/portworx-mirror-server/mirror-kernels.fedora.sh
+++ b/portworx-mirror-server/mirror-kernels.fedora.sh
@@ -22,6 +22,8 @@ mirror_ncsu_edu() {
     local top_url=http://ftp.linux.ncsu.edu/pub/fedora/linux/releases/
     local top_dir=$(url_to_dir "$top_url")
 
+    rename_bad_rpm_files "$top_dir"
+
     wget ${QUIET} --protocol-directories --force-directories \
 	  "${top_url}"
     save_error

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -23,20 +23,6 @@ versions_above_3_9 () {
     egrep "^v${above_3_9_regexp}.*/\$"
 }
 
-rename_bad_deb_files() {
-    local file
-    # FIXME?  Perhaps in the future, it would be better to maintain
-    # a list of files that have already been checked and only check new
-    # additions most of the time.  Better yet would be to have wget
-    # download files to a temporary name, and only move them into place
-    # after verifying them.
-    find "$@" -name '*.deb' -type f -print0 |
-	while read -r -d $'\0' file ; do
-	    if ! dpkg --contents "$file" > /dev/null 2>&1 ; then
-		mv --force "$file" "${file}.corrupt"
-	done
-}
-
 get_subdir_index_files() {
     local top_url="$1"
     echo_word_per_line "$@" |

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -94,3 +94,7 @@ rename_bad_pkg_files() {
 rename_bad_deb_files() {
     rename_bad_pkg_files '.deb' 'dpkg --contents' "$@"
 }
+
+rename_bad_rpm_files() {
+    rename_bad_pkg_files '.rpm' 'rpm --query --list' --package" "$@"
+}

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -88,6 +88,7 @@ rename_bad_pkg_files() {
 	while read -r -d $'\0' file ; do
 	    if ! $command "$file" > /dev/null 2>&1 ; then
 		mv --force "$file" "${file}.corrupt"
+	    fi
 	done
 }
 
@@ -96,5 +97,5 @@ rename_bad_deb_files() {
 }
 
 rename_bad_rpm_files() {
-    rename_bad_pkg_files '.rpm' 'rpm --query --list' --package" "$@"
+    rename_bad_pkg_files '.rpm' 'rpm --query --list --package' "$@"
 }

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -73,3 +73,24 @@ subdirs_to_urls() {
         echo "$top_url/$subdir"
     done
 }
+
+rename_bad_pkg_files() {
+    local extension="$1"
+    local command="$2"
+    local file
+    # FIXME?  Perhaps in the future, it would be better to maintain
+    # a list of files that have already been checked and only check new
+    # additions most of the time.  Better yet would be to have wget
+    # download files to a temporary name, and only move them into place
+    # after verifying them.
+    shift 2
+    find "$@" -name "*${extension}" -type f -print0 |
+	while read -r -d $'\0' file ; do
+	    if ! $command "$file" > /dev/null 2>&1 ; then
+		mv --force "$file" "${file}.corrupt"
+	done
+}
+
+rename_bad_deb_files() {
+    rename_bad_pkg_files '.deb' 'dpkg --contents' "$@"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -9,8 +9,8 @@ in_container_flock_deb() {
     # of he Ubuntu rebuild tests.
     local seconds=600
     local lockfile=/var/lib/dpkg/lock
-    in_container flock --timeout $seconds $lockfile \
-		 flock --unlock $lockfile "$@"
+    in_container flock --close --timeout $seconds $lockfile \
+		 flock --close --unlock $lockfile "$@"
 }
 
 dist_init_container_deb() {

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -79,6 +79,46 @@ prepare_pxfuse_dir() {
     fi
 }
 
+match_word() {
+    local small=$1
+    local big
+
+    shift
+    for big in "$@" ; do
+	case "$big" in
+	    "*${small}*" ) return 0 ;;
+	esac
+    done
+    return 1
+}
+
+
+matches_first() {
+    local releases="$1"
+    local file first unmatched
+    unmatched=""
+
+    shift
+
+    # Skip command options to get to path names
+    while true ; do
+	case "$1" in
+	    -- ) shift ; break ;;
+	    --* ) shift ;;
+	    * ) break ;;
+	    esac
+    done
+
+    for release in $releases ; do
+	if match_word "$release" "$@" ; then
+	    echo "$release"
+	else
+	    unmatched="$unmatched $release"
+	fi
+    done
+    echo $unmatched
+}
+
 test_kernel_pkgs() {
     local result release releases local make_args lockfile
 
@@ -94,8 +134,14 @@ test_kernel_pkgs() {
 
     result=1 # in case one of the loops should be empty for some reason.
 
-    for make_args in "" "CC=\"gcc -fno-pie\"" ; do
-	for release in $releases ; do
+    # The use of matches_first is an optimization that first tries operating
+    # system releases that appear somewhere in the paths of the package
+    # files being tested.  For Centos, which has releases like "6"
+    # and "7", this probably has little effect, but for Fedora, which
+    # is up in the two digits, and the Debian-based distributions that
+    # use names, it may be a more substantial improvement.
+    for release in $(matches_first "$releases" "$@") ; do
+	for make_args in "" "CC=\"gcc -fno-pie\"" ; do
 	    lockfile="$lockdir/container_${container_system}_${distro}_${release}"
 	    touch -f "$lockfile"
 	    flock --exclusive --close "$lockfile" \

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -86,7 +86,7 @@ match_word() {
     shift
     for big in "$@" ; do
 	case "$big" in
-	    "*${small}*" ) return 0 ;;
+	    *"${small}"* ) return 0 ;;
 	esac
     done
     return 1

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -81,6 +81,11 @@ if ! [[ -e "$pxfuse_dir" ]] ; then
     exit 1
 fi
 
+if ! [[ -d "$pxfuse_dir" ]] ; then
+    echo "$0: pxfuse directory ${pxfuse_dir} is not a directory." >&2
+    exit 1
+fi
+
 local_tmp_dir=/tmp/test-kernels.ubuntu.$$
 
 test_kernel_pkgs() {

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -76,6 +76,11 @@ if [[ -z "$pxfuse_dir" ]] ; then
     exit 1
 fi
 
+if ! [[ -e "$pxfuse_dir" ]] ; then
+    echo "$0: pxfuse directory ${pxfuse_dir} does not exist." >&2
+    exit 1
+fi
+
 local_tmp_dir=/tmp/test-kernels.ubuntu.$$
 
 test_kernel_pkgs() {


### PR DESCRIPTION
1. Detect truncated .deb and .rpm files and automatically move them out of the way just before updating mirrors.  This was the source of one of the Ubuntu build failures.

2. Try to guess which operating system release to start with based on file path name.  Often a package will correspond to a release that is no longer available as a container, so the speed up is not as dramatic as is t could be, but it should still help.

3. Abort earlier from certain errors that occur when I try to kill off some processes in a test run and not others.  The results appears to be the builds were getting into a state where they would install new packages, abort the build without removing the packages, and then move on to the next test.  This caused a huge numbers of kernel header files to accumulate, eventually causing the system to run out of inodes in the root file system.