### PR TITLE
Fix .rpm file truncation detection, commit a couple of minor changes that might be unnecessary

### DIFF
--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -97,5 +97,5 @@ rename_bad_deb_files() {
 }
 
 rename_bad_rpm_files() {
-    rename_bad_pkg_files '.rpm' 'rpm --query --list --package' "$@"
+    rename_bad_pkg_files '.rpm' rpm2cpio "$@"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -74,9 +74,11 @@ pkgs_update_deb()       {
 dist_clean_up_container_deb()
 {
     in_container_flock_deb sh -c "pkgs=\$( dpkg --list 'linux-headers-*' | awk '\$1 != \"un\" {print \$2;}' | egrep '^linux-headers-' ) ; dpkg --remove \$pkgs"
+    in_container_flock_deb apt-get --yes clean
 }
 
 install_pkgs_dir_deb()  {
+    in_container_flock_deb apt-get --yes clean
     in_container_flock_deb sh -c "dpkg --install --force-all $1/*"
     # in_container_flock_deb apt-get --fix-broken install --quiet --yes --force-yes || true
     # in_container_flock_deb apt-get --fix-broken install --yes --force-yes || true

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -3,6 +3,8 @@
 
 dist_init_container_rpm() {
     install_pkgs_rpm autoconf automake gcc gcc-c++ git make tar
+
+    uninstall_pkgs_rpm kernel-devel   # FIXME? Is this command necessary?
 }
 
 pkg_files_to_kernel_dirs_rpm() {
@@ -33,7 +35,21 @@ install_pkgs_dir_rpm() {
     in_container sh -c "yum --assumeyes install $1/*"
 }
 
+install_pkgs_dir_rpm_notyet()
+{
+    # in_container sh -c "yum --assumeyes install $1/*" ;
+    # yum fails when asked to install a file that is already installed.
+    # So, try to install the packages one by one, until all installs fail.
+    in_container sh -c "yum --assumeyes --skip-broken install $1/*" ;
+    return $?	 # AJR
+    while in_container sh -c \
+	"for pkgfile in $1/* ; do yum --assumeyes install \$pkgfile && exit 0 ; done ; false" ; do
+	true
+    done
+}
+
 install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
-uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
+#uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
+uninstall_pkgs_rpm()   { in_container yum --assumeyes remove "$@" ; }
 pkgs_update_rpm()      { in_container yum --assumeyes --quiet update ; }
 dist_clean_up_container_rpm() { true; }	# No-op for now.


### PR DESCRIPTION
The change to use rpm2cpio to test .rpm files for truncation is important, as the previous method I was using was not always detecting it.

The other changes are just changes that I have had in my source tree that might not be necessary but is the code that has been running on mirrors.portworx.com lately (using "apt-get --yes clean" and using yum instead of the rpm program to remove rpm packages).
