### PR TITLE
Changes to logging: logs moved to /var/log, HTML test report includes regressions

### DIFF
--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -38,9 +38,10 @@ install_httpd_ubuntu:
 	mv /var/www/html/index.html /var/www/html/index.html.orig 2> /dev/null || true
 
 install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_ubuntu
+	mkdir -p /var/log/portworx-mirror-server
 	adduser --system pwxmirror
 	chsh --shell /bin/bash pwxmirror
-	chown -R pwxmirror /home/pwxmirror
+	chown -R pwxmirror /home/pwxmirror /var/log/portworx-mirror-server
 	crontab -u pwxmirror ${scriptsdir}/crontab.txt
 	( . ${scriptsdir}/pwx-mirror-config.sh && \
 	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/ubuntu && for subdir in centos debian ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -39,6 +39,8 @@ install_httpd_ubuntu:
 
 install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_ubuntu
 	adduser --system pwxmirror
+	chsh --shell /bin/bash pwxmirror
+	chown -R pwxmirror /home/pwxmirror
 	crontab -u pwxmirror ${scriptsdir}/crontab.txt
 	( . ${scriptsdir}/pwx-mirror-config.sh && \
 	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/ubuntu && for subdir in centos debian ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -42,9 +42,12 @@ install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_
 	adduser --system pwxmirror
 	chsh --shell /bin/bash pwxmirror
 	chown -R pwxmirror /home/pwxmirror /var/log/portworx-mirror-server
-	crontab -u pwxmirror ${scriptsdir}/crontab.txt
 	( . ${scriptsdir}/pwx-mirror-config.sh && \
 	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/ubuntu && for subdir in centos debian ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )
+#	crontab -u pwxmirror ${scriptsdir}/crontab.txt
+#	^^^^^ Do not install the crontab for now, as the current  plan
+#	      is for the cron script to be run by Jensen.
+
 
 install_mirror: install_mirror_scripts install_mirror_ubuntu
 

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -4,7 +4,7 @@
 scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh
 . ${scriptsdir}/pwx-mirror-util.sh
-logdir=${scriptsdir}/logs
+logdir=/var/log/portworx-mirror-server
 logfile=${logdir}/$(date +%Y%m%d.%H:%M:%S).log
 
 error_code=0
@@ -30,10 +30,15 @@ copy_link_tree_remove_index_html()
 run_all_verb_scripts()
 {
     local verb="$1"
+    local basename logfile
     set -x
     for script in ${scriptsdir}/${verb}-kernels.*.sh ; do
-        $script
+	basename="${script##*/}"
+	logfile="$logdir/$basename"
+	mv --force "$logfile" "${logfile}.old" > /dev/null 2>&1 || true
+        $script > "$logfile" 2>&1 &
     done
+    wait
 }
 
 run_all_mirror_scripts()

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+# ^^^^^^^^^ /bin/bash because pwx-mirror-util.sh uses "[[".
 
 scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -5,7 +5,7 @@ scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-config.sh
 . ${scriptsdir}/pwx-mirror-util.sh
 logdir=/var/log/portworx-mirror-server
-logfile=${logdir}/$(date +%Y%m%d.%H:%M:%S).log
+main_logfile=${logdir}/cron-script.log
 
 error_code=0
 
@@ -34,7 +34,7 @@ run_all_verb_scripts()
     set -x
     for script in ${scriptsdir}/${verb}-kernels.*.sh ; do
 	basename="${script##*/}"
-	logfile="$logdir/$basename"
+	logfile="$logdir/${basename}.log"
 	mv --force "$logfile" "${logfile}.old" > /dev/null 2>&1 || true
         $script > "$logfile" 2>&1 &
     done
@@ -61,7 +61,8 @@ run_all_test_scripts()
 
 mkdir -p "$logdir"
 
-( run_all_mirror_scripts ; run_all_test_scripts ) > "$logfile" 2>&1 < /dev/null
+mv --force "$main_logfile" "${main_logfile}.old}"
+( run_all_mirror_scripts ; run_all_test_scripts ) > "$main_logfile" 2>&1 < /dev/null
 save_error
 
 exit $error_code

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -30,15 +30,20 @@ copy_link_tree_remove_index_html()
 run_all_verb_scripts()
 {
     local verb="$1"
-    local basename logfile
-    set -x
+    local basename logfile pids pid
+
+    pids=""
     for script in ${scriptsdir}/${verb}-kernels.*.sh ; do
 	basename="${script##*/}"
 	logfile="$logdir/${basename}.log"
 	mv --force "$logfile" "${logfile}.old" > /dev/null 2>&1 || true
         $script > "$logfile" 2>&1 &
+	pids="$pids $!"
     done
-    wait
+    for pid in $pids ; do
+	wait -n $pid
+	save_error
+    done
 }
 
 run_all_mirror_scripts()

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -36,7 +36,9 @@ run_all_verb_scripts()
     for script in ${scriptsdir}/${verb}-kernels.*.sh ; do
 	basename="${script##*/}"
 	logfile="$logdir/${basename}.log"
-	mv --force "$logfile" "${logfile}.old" > /dev/null 2>&1 || true
+	if [[ -e "$logfile" ]] ; then
+	    mv --force "$logfile" "${logfile}.old"
+	fi
         $script > "$logfile" 2>&1 &
 	pids="$pids $!"
     done
@@ -66,7 +68,9 @@ run_all_test_scripts()
 
 mkdir -p "$logdir"
 
-mv --force "$main_logfile" "${main_logfile}.old}"
+if [[ -e "$main_logfile" ]] ; then
+    mv --force "$main_logfile" "${main_logfile}.old}"
+fi
 ( run_all_mirror_scripts ; run_all_test_scripts ) > "$main_logfile" 2>&1 < /dev/null
 save_error
 

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -39,6 +39,7 @@ run_all_verb_scripts()
 	    mv --force "$logfile" "${logfile}.old"
 	fi
         $script > "$logfile" 2>&1
+	save_error
     done
 }
 

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -30,21 +30,15 @@ copy_link_tree_remove_index_html()
 run_all_verb_scripts()
 {
     local verb="$1"
-    local basename logfile pids pid
+    local basename logfile
 
-    pids=""
     for script in ${scriptsdir}/${verb}-kernels.*.sh ; do
 	basename="${script##*/}"
 	logfile="$logdir/${basename}.log"
 	if [[ -e "$logfile" ]] ; then
 	    mv --force "$logfile" "${logfile}.old"
 	fi
-        $script > "$logfile" 2>&1 &
-	pids="$pids $!"
-    done
-    for pid in $pids ; do
-	wait -n $pid
-	save_error
+        $script > "$logfile" 2>&1
     done
 }
 

--- a/portworx-mirror-server/mirror-kernels.ubuntu.sh
+++ b/portworx-mirror-server/mirror-kernels.ubuntu.sh
@@ -27,7 +27,7 @@ get_subdir_index_files() {
     local top_url="$1"
     echo_word_per_line "$@" |
         subdirs_to_urls "${top_url}"  |
-        xargs -- wget ${TIMESTAMPING} --quiet --protocol-directories \
+        xargs -- wget --quiet --protocol-directories \
 	      --force-directories --accept=index.html --recursive
     save_error
 }

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -18,6 +18,16 @@ install_scripts() {
     done
 }
 
+install_crontab() {
+    old_crontab=$( ( crontab -u root -l 2> /dev/null ) |
+		       egrep -v pwx_test_kernels.cron_script.sh |
+		       egrep -v '^#' ) || true
+
+    ( echo "$old_crontab" ;
+      echo "15 1 * * * $scriptsdir/pwx_test_kernels.cron_script.sh" ) |
+	crontab -u root -
+}
+
 apt-get install --yes --quiet rpm
 # Needed for Centos support, for extracting information from .rpm files.
 
@@ -38,12 +48,10 @@ chmod a+x \
       "${scriptsdir}/pwx_update_pxfuse_by_date.sh" \
       "${scriptsdir}/test_report.sh"
 
-old_crontab=$( ( crontab -u root -l 2> /dev/null ) |
-	      egrep -v pwx_test_kernels.cron_script.sh |
-	      egrep -v '^#' ) || true
-( echo "$old_crontab" ;
-  echo "15 1 * * * $scriptsdir/pwx_test_kernels.cron_script.sh" ) |
-    crontab -u root -
+# For now, comment out the installation of the crontab, as the cron
+# script will be run by Jenson.
+#
+# install_crontab
 
 rm -f /var/www/html/build-results
 ln -s ${build_results_dir} /var/www/html/build-results

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -2,8 +2,11 @@
 
 scriptsdir=$PWD
 
-log_file=/home/ubuntu/pwx_test_kernels.cron_script.sh.log
+log_file=/var/log/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.log
 
+mkdir -p "${log_file%/*}"
+
+mv --force "$log_file" "${log_file}.old"
 exec > "$log_file" 2>&1 < /dev/null
 
 PATH=/usr/local/bin:$PATH

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -3,6 +3,19 @@
 
 cd /home/ftp/build-results/pxfuse/by-date/latest || exit $?
 
+prev_test=/home/ftp/build-results/pxfuse/old/test_report
+
+exit_code_files_to_dirs() {
+    # Usage: exit_code_files_to_dirs subdir [grep_args...]
+    #   Usually grep_args is "-l" or "-L"
+    local subdir="$1"
+    
+    shift
+    find "$subdir" -name exit_code -print0 |
+	xargs --null --no-run-if-empty -- egrep "$@" '^0 ' |
+	sort -u
+}
+
 output_html_header() {
     local title="$1"
 cat <<EOF
@@ -40,6 +53,43 @@ output_html_link_and_note_paragraph() {
     echo ""
 }
 
+files_to_html_link_page()
+{
+    local title="$1"
+    local file exit_code rest
+
+    output_html_header "$title"
+    while read file ; do
+	read exit_code rest < "$file"
+	output_html_link_and_note_paragraph "../../${file%/exit_code}" "$rest"
+    done
+    output_html_trailer
+}
+
+regression_detected()
+{
+    echo ""
+    echo "$0:"
+    echo "\"regression_detected $*\" called."
+    echo "This is a stub function that could perhaps be used to notify staff"
+    echo "when a regression has beendetected by, sending e-mail, text"
+    echo "message, etc."
+    echo ""
+}
+
+if [[ -e test_report ]] ; then
+    mkdir -p "$prev_test"
+    rm -rf test_report/old
+    mv "$prev_test" test_report/old
+    mv test_report "$prev_test"
+
+    # Trim logs at some point:
+    rm -rf "$prev_test/old/old/old"
+
+    # The .html files will not have valid links once the files have been
+    # moved, so just remove those files, to avoid confusion.
+    find "$prev_test" -name '*.html' -type f -print0 | xargs --null rm -f
+fi
 
 mkdir -p test_report
 rm -f test_report/test_report.txt
@@ -47,49 +97,55 @@ rm -f test_report/test_report.txt
 what_we_are_doing="building Portworx px.ko kernel module"
 
 output_html_header "Test report for $what_we_are_doing" \
-    > test_report/test_report.html
+		   > test_report/test_report.html
 
+regression_distros=""
 for dir in */ ; do
-    if [[ "$dir" = "test_report/" ]] ; then
-        continue
-    fi
+
+    case "$dir" in
+	test_report*/ | old/ ) continue ;;
+    esac
 
     distribution=${dir%/}
     out_dir="test_report/$distribution"
     mkdir -p "$out_dir"
 
-    success_count=$(find "$distribution" -name exit_code -print0 | xargs --null --no-run-if-empty -- egrep -l '^0 ' | wc -l)
-    fail_count=$(find "$distribution" -name exit_code -print0 | xargs --null --no-run-if-empty -- egrep -L '^0 ' | wc -l)
+    exit_code_files_to_dirs "$distribution" "-l" > "$out_dir/successes.txt"
+    exit_code_files_to_dirs "$distribution" "-L" > "$out_dir/fails.txt"
 
-    output_html_header "Successes for $what_we_are_doing on $distribution" \
-		       > "${out_dir}/successes.html"
-    output_html_header "Failures for $what_we_are_doing on $distribution" \
-		       > "${out_dir}/failures.html"
-    find "$distribution" -name exit_code | sort --unique |
-        while read filename ; do
-            read exit_code rest < "$filename"
+    cat "$prev_test/$distribution/successes.txt" "$out_dir/fails.txt" |
+	sort | uniq --repeated > "$out_dir/regressions.txt"
 
-            if [ ".$exit_code" = ".0" ] ; then
-                out_file="${out_dir}/successes.html"
-            else
-                out_file="${out_dir}/failures.html"
-            fi
-            link="../../${filename%/exit_code}"
-	    output_html_link_and_note_paragraph "$link" "$rest" >> "$out_file"
-        done
-    output_html_trailer >> "${out_dir}/successes.html"
-    output_html_trailer >> "${out_dir}/failures.html"
+    cat "$prev_test/$distribution/fails.txt" "$out_dir/successes.txt" |
+	sort | uniq --repeated > "$out_dir/fixed.txt"
 
-    echo "${distribution}: $success_count pass, $fail_count fail." >> test_report/test_report.txt
+    regression_count=$(wc -l < "$out_dir/regressions.txt")
+    if [[ $regression_count -gt 0 ]] ; then
+	regression_distros="$regression_distros $distribution"
+    fi
 
-    echo "
-<P>
-<A href=\"../${distribution}\"> ${distribution}:</A>
-<A href=\"${distribution}/successes.html\"> $success_count pass</A>,
-<A href=\"${distribution}/failures.html\"> $fail_count fail</A>.
-</P>
-" >> test_report/test_report.html
+    echo -n "${distribution}: " >> test_report/test_report.txt
+    echo "<P>
+          <A href=\"../${distribution}\"> ${distribution}:</A>" \
+	 >> test_report/test_report.html
 
-done
+    maybe_comma=""
+    for word in successes fails regressions fixed ; do
+	files_to_html_link_page \
+	    "$word for $what_we_are_doing on $distribution" \
+	    < $out_dir/$word.txt > "${out_dir}/${word}.html"
+
+	count=$(wc -l < "${out_dir}/${word}.txt")
+	echo -n "$maybe_comma $count $word" >> test_report/test_report.txt
+	maybe_comma=","
+	echo "<A href=\"${distribution}/${word}.html\"> $count ${word}</A>," \
+	     >> test_report/test_report.html
+    done # for word in ...
+    ( echo "" ; echo "</P>" ) >> test_report/test_report.html
+done # for dir (distribution) in...
 
 output_html_trailer >> test_report/test_report.html
+
+if [[ -n "$regression_distros" ]] ; then
+    regression_detected $regression_distros
+fi


### PR DESCRIPTION
These changes primarily involve logging. Log files have been moved from various home directories to /var/log and are named are deleted after a couple of generations.

The HTML test results page at http://mirrors.portworx.com/build-results/pxfuse/by-date/latest/test_report/test_report.html now has addition sub-pages for "regressions" (changes from success to failure) and fixed (changes from failure to success).

The script that makes these HTML files also has a stub function that is called if any regressions were detected.  My thinking is that perhaps, in the future, someone might want to put some shell commands in that function to send email, text messages, or other notifications to the appropriate staff people.

In the commits, there was also a change where I attempted to run the mirror scripts in parallel for each operating system distribution, but then decided it was too difficult to collect exit statuses from a shell script to do that right now.  So, subsequent commits in this series basically r