### PR TITLE
Fix bug due to cron not including sbin directories in path, fix some incorrect declarations, many clean ups

### DIFF
--- a/pwx_test_kernel_pkgs/container_driver.docker.sh
+++ b/pwx_test_kernel_pkgs/container_driver.docker.sh
@@ -31,10 +31,12 @@ start_container_docker() {
     if [[ -n "$id" ]] ; then
 	docker start "$id"
 	docker_pid="$id"
-	return 0
+	dist_start_container
+	return $?
     else
 	docker pull $distribution
         docker_pid=$(docker run --interactive --name "${container_name}" --detach "$distribution" bash)
+	dist_start_container
 	"$@"
     fi
 }

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -5,7 +5,8 @@ container_name=
 
 # To use LXC containers, for now, the script must be running as superuser.
 
-use_lxc_attach=true
+# lxc_exec_command=lxc-execute
+lxc_exec_command=lxc-attach
 
 await_default_route() {
     local count=100
@@ -67,7 +68,7 @@ start_container_lxc() {
 		     --dist "$distro" --arch "$arch" --release "$release"
     fi
 
-    if $use_lxc_attach ; then
+    if [[ ".$lxc_exec_command" = ".lxc-attach" ]] ; then
 	if ! is_container_running "${container_name}" ; then
             lxc-start --name "${container_name}" --daemon
 	fi
@@ -100,16 +101,17 @@ start_container_lxc() {
 }
 
 stop_container_lxc() {
-#    if $use_lxc_attach ; then
+#    if [[ ".$lxc_exec_command" = ".lxc-attach" ]] ; then
 #	lxc-stop --name "$container_name"
 #    fi
     true
 }
 
 in_container_lxc() {
-    if $use_lxc_attach ; then
-        lxc-attach --name "$container_name" -- "$@"
-    else
-        lxc-execute --name "$container_name" -- "$@"
-    fi
+    "$lxc_exec_command" --name "$container_name" -- \
+        env --ignore-environment \
+            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+	    SHELL=/bin/sh \
+	    USER=root \
+	    "$@"
 }

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -81,8 +81,6 @@ start_container_lxc() {
 	in_container_lxc /etc/init.d/network restart
 
 	await_default_route
-    else
-	echo "AJR start_container_lxc: first await_default_route succeeded." >&2	    
     fi
 
     if ! await_dns ; then

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -93,6 +93,7 @@ start_container_lxc() {
 	fi
     fi
 
+    dist_start_container
     if $must_initialize ; then
 	"$@"
     fi

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -101,10 +101,10 @@ stop_container_lxc() {
 }
 
 in_container_lxc() {
-    lxc-attach --name "$container_name" -- \
-        env --ignore-environment \
+    lxc-attach --name "$container_name" --clear-env \
+        --set-var \
             PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-	    SHELL=/bin/sh \
-	    USER=root \
-	    "$@"
+	--set-var SHELL=/bin/sh \
+	--set-var USER=root \
+	-- "$@"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -14,6 +14,7 @@ pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }
 dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }
 dist_clean_up_container_fedora()  { dist_clean_up_container_rpm   "$@" ; }
+dist_start_container_centos()     { dist_start_container_rpm      "$@"; }
 
 get_dist_releases_centos()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -13,7 +13,7 @@ uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_centos()    { test_kernel_pkgs_func_default "$@" ; }
 dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }
-dist_clean_up_container_fedora()  { dist_clean_up_container_rpm   "$@" ; }
+dist_clean_up_container_centos()  { dist_clean_up_container_rpm   "$@" ; }
 dist_start_container_centos()     { dist_start_container_rpm      "$@"; }
 
 get_dist_releases_centos()

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -54,13 +54,13 @@ pkg_files_to_dependencies_deb() {
 }
 
 install_pkgs_deb()      {
-    in_container_flock_deb apt-get install --quiet --yes --force-yes "$@"
+    in_container_flock_deb apt-get install --quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages "$@"
 }
 
 # uninstall_pkgs_deb()    { in_container_flock_deb dpkg --remove "$@" ; }
 uninstall_pkgs_deb()    {
     local pkg
-    if ! in_container_flock_deb apt-get remove --quiet --yes --force-yes "$@" ; then
+    if ! in_container_flock_deb apt-get remove --quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages "$@" ; then
 	for pkg in "$@" ; do
 	    in_container_flock_deb dpkg --remove --force-remove-reinstreq "$pkg"
 	done
@@ -68,7 +68,7 @@ uninstall_pkgs_deb()    {
 }
 
 pkgs_update_deb()       {
-    in_container_flock_deb apt-get update --quiet --yes --force-yes
+    in_container_flock_deb apt-get update --quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages
 }
 
 dist_clean_up_container_deb()
@@ -80,7 +80,7 @@ dist_clean_up_container_deb()
 install_pkgs_dir_deb()  {
     in_container_flock_deb apt-get --yes clean
     in_container_flock_deb sh -c "dpkg --install --force-all $1/*"
-    # in_container_flock_deb apt-get --fix-broken install --quiet --yes --force-yes || true
-    # in_container_flock_deb apt-get --fix-broken install --yes --force-yes || true
+    # in_container_flock_deb apt-get --fix-broken install --quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages || true
+    # in_container_flock_deb apt-get --fix-broken install --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages || true
     # ^^^ Try to install any missing dependencies.
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -10,7 +10,8 @@ in_container_flock_deb() {
     local seconds=600
     local lockfile=/var/lib/dpkg/lock
     in_container flock --close --timeout $seconds $lockfile \
-		 flock --close --unlock $lockfile "$@"
+		 flock --close --unlock $lockfile \
+		 env DEBIAN_FRONTEND=noninteractive "$@"
 }
 
 dist_init_container_deb() {

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -108,7 +108,14 @@ pkgs_update_deb()       {
 
 dist_clean_up_container_deb()
 {
-    in_container_flock_deb sh -c "pkgs=\$( dpkg --list 'linux-headers-*' | awk '\$1 != \"un\" {print \$2;}' | egrep '^linux-headers-' ) ; dpkg --remove \$pkgs"
+    in_container_flock_deb sh -c "
+	pkgs=\$( dpkg --list 'linux-headers-*' |
+            awk '\$1 != \"un\" {print \$2;}' |
+            egrep '^linux-headers-' )
+        if [ -n \"\$pkgs\" ] ; then
+	    dpkg --remove \$pkgs
+        fi
+    "
     in_container_flock_deb apt-get --yes clean
 }
 

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -15,7 +15,7 @@
 
 # Global variable determine which arguments to pass to apt-get to
 # tell it it just do what was requests while avoiding warning messages:
-deb_apt_get_args="--quiet --yes --force-yes"
+deb_apt_get_args="--quiet --quiet --yes --force-yes"
 
 in_container_env_deb() {
     in_container env --ignore-environment \
@@ -42,10 +42,10 @@ in_container_flock_deb() {
 
 dist_start_container_deb()
 {
-    if in_container_flock_deb apt-get install --quiet --yes --allow-downgrades bash ; then
-	deb_apt_get_args="--quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages"
+    if in_container_flock_deb apt-get install --quiet --quiet --yes --allow-downgrades bash ; then
+	deb_apt_get_args="--quiet --quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages"
     else
-	deb_apt_get_args="--quiet --yes --force-yes"
+	deb_apt_get_args="--quiet --quiet --yes --force-yes"
     fi
 }
 

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -17,15 +17,6 @@
 # tell it it just do what was requests while avoiding warning messages:
 deb_apt_get_args="--quiet --quiet --yes --force-yes"
 
-in_container_env_deb() {
-    in_container env --ignore-environment \
-	 DEBIAN_FRONTEND=noninteractive \
-	 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-	 SHELL=/bin/sh \
-	 USER=root \
-	 "$@"
-}
-
 in_container_flock_deb() {
     # Do an in_container command, but block for up to five minutes to
     # acquire (and release) the dpkg lock, to reduce the change of the
@@ -34,7 +25,7 @@ in_container_flock_deb() {
     # of he Ubuntu rebuild tests.
     local seconds=600
     local lockfile=/var/lib/dpkg/lock
-    in_container_env_deb \
+    in_container env DEBIAN_FRONTEND=noninteractive \
 	flock --close --timeout $seconds $lockfile \
 	flock --close --unlock $lockfile \
 	"$@"

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -17,8 +17,7 @@ dist_init_container_deb() {
     in_container_flock_deb apt-get update --quiet --yes
     # ^^^ Skip this for binary reproducibility ??
 
-    in_container_flock_deb apt-get install --quiet --yes \
-		 autoconf g++ gcc git libelf-dev libssl1.0 make tar
+    install_pkgs_deb autoconf g++ gcc git libelf-dev libssl1.0 make tar
     # TODO?: install gcc-5?
     # Why px-fuse wants git is unclear to me.
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -43,9 +43,9 @@ in_container_flock_deb() {
 dist_start_container_deb()
 {
     if in_container_flock_deb apt-get install --quiet --yes --allow-downgrades bash ; then
-	deb_apt_get_args="--quiet --yes --force-yes"
-    else
 	deb_apt_get_args="--quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages"
+    else
+	deb_apt_get_args="--quiet --yes --force-yes"
     fi
 }
 

--- a/pwx_test_kernel_pkgs/distro_driver.debian.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.debian.sh
@@ -15,6 +15,7 @@ uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_debian()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_debian()    { test_kernel_pkgs_func_default "$@" ; }
 dist_clean_up_container_debian()  { dist_clean_up_container_deb   "$@" ; }
+dist_start_container_ubuntu()     { dist_start_container_deb      "$@"; }
 
 get_dist_releases_debian()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.debian.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.debian.sh
@@ -15,7 +15,7 @@ uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_debian()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_debian()    { test_kernel_pkgs_func_default "$@" ; }
 dist_clean_up_container_debian()  { dist_clean_up_container_deb   "$@" ; }
-dist_start_container_ubuntu()     { dist_start_container_deb      "$@"; }
+dist_start_container_debian()     { dist_start_container_deb      "$@"; }
 
 get_dist_releases_debian()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -13,6 +13,7 @@ pkgs_update_fedora()              { pkgs_update_rpm               "$@" ; }
 test_kernel_pkgs_func_fedora()    { test_kernel_pkgs_func_default "$@" ; }
 dist_init_container_fedora()      { dist_init_container_rpm       "$@" ; }
 dist_clean_up_container_fedora()  { dist_clean_up_container_rpm   "$@" ; }
+dist_start_container_fedora()     { dist_start_container_rpm      "$@"; }
 
 get_dist_releases_fedora()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -1,20 +1,6 @@
 # This is not a standalone program.  It is a library to be sourced by a shell
 # script.
 
-in_container_env_rpm() {
-    # cron does not include the sbin directories in the $PATH that it
-    # provides, and lxc-attach passes the provided environment variables,
-    # including PATH. So, PATH to something that includes the sbin
-    # directories, and, also, to reduce variation, set the rest of
-    # the environment to something simple and standard.
-
-    in_container env --ignore-environment \
-	 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-	 SHELL=/bin/sh \
-	 USER=root \
-	 "$@"
-}
-
 dist_init_container_rpm() {
     install_pkgs_rpm autoconf automake gcc gcc-c++ git make tar
 
@@ -43,28 +29,28 @@ pkg_files_to_dependencies_rpm() {
 	sort -u
 }
 
-#install_pkgs_dir_rpm() { in_container_env_rpm sh -c "rpm --install $1/*" ; }
+#install_pkgs_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
 install_pkgs_dir_rpm() {
-    in_container_env_rpm sh -c "yum --assumeyes upgrade $1/*"
-    in_container_env_rpm sh -c "yum --assumeyes install $1/*"
+    in_container sh -c "yum --assumeyes upgrade $1/*"
+    in_container sh -c "yum --assumeyes install $1/*"
 }
 
 install_pkgs_dir_rpm_notyet()
 {
-    # in_container_env_rpm sh -c "yum --assumeyes install $1/*" ;
+    # in_container sh -c "yum --assumeyes install $1/*" ;
     # yum fails when asked to install a file that is already installed.
     # So, try to install the packages one by one, until all installs fail.
-    in_container_env_rpm sh -c "yum --assumeyes --skip-broken install $1/*" ;
+    in_container sh -c "yum --assumeyes --skip-broken install $1/*" ;
     return $?	 # AJR
-    while in_container_env_rpm sh -c \
+    while in_container sh -c \
 	"for pkgfile in $1/* ; do yum --assumeyes install \$pkgfile && exit 0 ; done ; false" ; do
 	true
     done
 }
 
-install_pkgs_rpm()     { in_container_env_rpm yum --assumeyes --quiet install "$@" ; }
-#uninstall_pkgs_rpm()   { in_container_env_rpm rpm --erase "$@" ; }
-uninstall_pkgs_rpm()   { in_container_env_rpm yum --assumeyes remove "$@" ; }
-pkgs_update_rpm()      { in_container_env_rpm yum --assumeyes --quiet update ; }
+install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
+#uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
+uninstall_pkgs_rpm()   { in_container yum --assumeyes remove "$@" ; }
+pkgs_update_rpm()      { in_container yum --assumeyes --quiet update ; }
 dist_clean_up_container_rpm() { true; }	# No-op for now.
 dist_start_container_rpm() { true; }

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -67,3 +67,4 @@ install_pkgs_rpm()     { in_container_env_rpm yum --assumeyes --quiet install "$
 uninstall_pkgs_rpm()   { in_container_env_rpm yum --assumeyes remove "$@" ; }
 pkgs_update_rpm()      { in_container_env_rpm yum --assumeyes --quiet update ; }
 dist_clean_up_container_rpm() { true; }	# No-op for now.
+dist_start_container_rpm() { true; }

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -1,6 +1,20 @@
 # This is not a standalone program.  It is a library to be sourced by a shell
 # script.
 
+in_container_env_rpm() {
+    # cron does not include the sbin directories in the $PATH that it
+    # provides, and lxc-attach passes the provided environment variables,
+    # including PATH. So, PATH to something that includes the sbin
+    # directories, and, also, to reduce variation, set the rest of
+    # the environment to something simple and standard.
+
+    in_container env --ignore-environment \
+	 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+	 SHELL=/bin/sh \
+	 USER=root \
+	 "$@"
+}
+
 dist_init_container_rpm() {
     install_pkgs_rpm autoconf automake gcc gcc-c++ git make tar
 
@@ -29,27 +43,27 @@ pkg_files_to_dependencies_rpm() {
 	sort -u
 }
 
-#install_pkgs_dir_rpm() { in_container sh -c "rpm --install $1/*" ; }
+#install_pkgs_dir_rpm() { in_container_env_rpm sh -c "rpm --install $1/*" ; }
 install_pkgs_dir_rpm() {
-    in_container sh -c "yum --assumeyes upgrade $1/*"
-    in_container sh -c "yum --assumeyes install $1/*"
+    in_container_env_rpm sh -c "yum --assumeyes upgrade $1/*"
+    in_container_env_rpm sh -c "yum --assumeyes install $1/*"
 }
 
 install_pkgs_dir_rpm_notyet()
 {
-    # in_container sh -c "yum --assumeyes install $1/*" ;
+    # in_container_env_rpm sh -c "yum --assumeyes install $1/*" ;
     # yum fails when asked to install a file that is already installed.
     # So, try to install the packages one by one, until all installs fail.
-    in_container sh -c "yum --assumeyes --skip-broken install $1/*" ;
+    in_container_env_rpm sh -c "yum --assumeyes --skip-broken install $1/*" ;
     return $?	 # AJR
-    while in_container sh -c \
+    while in_container_env_rpm sh -c \
 	"for pkgfile in $1/* ; do yum --assumeyes install \$pkgfile && exit 0 ; done ; false" ; do
 	true
     done
 }
 
-install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
-#uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
-uninstall_pkgs_rpm()   { in_container yum --assumeyes remove "$@" ; }
-pkgs_update_rpm()      { in_container yum --assumeyes --quiet update ; }
+install_pkgs_rpm()     { in_container_env_rpm yum --assumeyes --quiet install "$@" ; }
+#uninstall_pkgs_rpm()   { in_container_env_rpm rpm --erase "$@" ; }
+uninstall_pkgs_rpm()   { in_container_env_rpm yum --assumeyes remove "$@" ; }
+pkgs_update_rpm()      { in_container_env_rpm yum --assumeyes --quiet update ; }
 dist_clean_up_container_rpm() { true; }	# No-op for now.

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -12,6 +12,7 @@
 
 get_dist_releases()        { "get_dist_releases_$distro"        "$@" ; }
 dist_init_container()      { "dist_init_container_$distro"      "$@" ; }
+dist_start_container()     { "dist_start_container_$distro"     "$@" ; }
 pkg_files_to_kernel_dirs() { "pkg_files_to_kernel_dirs_$distro" "$@" ; }
 pkg_files_to_names()       { "pkg_files_to_names_$distro"       "$@" ; }
 pkg_files_to_dependencies() { "pkg_files_to_dependencies_$distro" "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -13,6 +13,7 @@ uninstall_pkgs_ubuntu()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_ubuntu()              { pkgs_update_deb               "$@" ; }
 test_kernel_pkgs_func_ubuntu()    { test_kernel_pkgs_func_default "$@" ; }
 dist_clean_up_container_ubuntu()  { dist_clean_up_container_deb   "$@" ; }
+dist_start_container_ubuntu()     { dist_start_container_deb      "$@"; }
 
 get_dist_releases_ubuntu()
 {

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -83,6 +83,18 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 	dist_init_container	-  Install any needed initial
 				   packages in the initial container.
 
+	dist_start_container	-  Called every time a container is
+				   started (not just created from scratch).
+				   This is currently used with
+				   Debian-based container to check and
+				   record which versions of "apt-get"
+				   command line options are accepted.
+				   This function is called by the container
+				   driver, and is called before
+				   dist_init_container, so that
+				   dist_init_container can rely on the
+				   results of this function.
+
 	pkg_files_to_kernel_dirs - Extract the kernel directory strings
 				  from the given list of kernel header
 				  packages.

--- a/pwx_test_kernel_pkgs/programming-interface.txt
+++ b/pwx_test_kernel_pkgs/programming-interface.txt
@@ -8,11 +8,20 @@ Top level scripts, installed in /usr/local/bin:
 
 	Each of the following scripts accepts a common set of options,
 	listed below.
-
-
-
+	
 
 	pwx_test_kernel_pkgs [options] pkg_files...
+	pwx_test_kernel_pkgs_one_container.sh [options] pkg_files...
+
+ 	    pwx_test_kernel_pkgs iterates through the operating system
+	    releases suported by the specified opreating system distribution
+	    (for example, if "ubuntu" is the distribution, "xenial",
+	    "yakkety", etc. are the releases), terminating as soon as
+	    pwx_test_kernels_pkgs_one_container.sh returns success (exit
+	    code of zero).  pwx_test_kernel_pkgs_one_container.sh is
+	    the script that actually does the work of running the test.
+	    It is installed in /usr/local/share/pwx_test_kernel_pkgs/scripts.
+	    pwx_test_kernel_pkgs is installed in /usr/local/bin.
 
 	    Options:
 		
@@ -25,7 +34,13 @@ Top level scripts, installed in /usr/local/bin:
 		--logdir=logdir                [default: based on distribution]
 		--pfxuse=pxfuse_src_dir        [default: download tempoary
 					        directory from github]
-		--release=dist_release         [default: based on distribution]
+		--releases=dist_release        [default: based on distribution]
+
+            pwx_test_kernel_pkgs_one_releaese.sh accepts the additional
+	    option "--release=..." and ignores "--releases=....".  In this
+	    way, pwx_test_kenrel_pkgs can tell
+	    pwx_test_kernel_pkgs_one_release.sh which release to test,
+	    withing need to delete anything from its command line arguments.
 
 	    Description:
 

--- a/pwx_test_kernel_pkgs/pwx_test_containers_stop.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_containers_stop.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# ^^^^^^^^^ bash because it uses "[["
+# Stops all Linux containers that pwx_test_containers might have started.
+
+scriptsdir=$PWD
+
+usage() {
+    echo "Usage: pwx_test_containers_stop.sh [--distribution=dist] [--containers=container_system] [--releases=releases]"
+    echo "    Stops all containers used by pwx_test_kernel_pkgs for the"
+    echo "    specified operating system distribution releases."
+    echo ""
+}
+
+arch=amd64
+distro=ubuntu
+distro_releases=""
+container_system=lxc
+
+
+. ${scriptsdir}/container_driver.sh
+. ${scriptsdir}/distro_driver.sh
+
+while [[ $# -gt 0 ]] ; do
+    case "$1" in
+	--arch=* ) arch=${1#--arch=} ;;	  # Unused, but allow it for now.
+	--containers=* ) container_system=${1#--containers=} ;;
+	--distribution=* ) distro=${1#--distribution=} ;;
+	--releases=* ) distro_release=${1#--releases=} ;;
+	--* ) usage >&2 ; exit 1 ;;
+	* ) break ;;
+    esac
+    shift
+done
+
+main()
+{
+    local releaes releases
+
+    if [[ -n "$distro_releases" ]] ; then
+	releases=$(echo "$distro_releases" | sed 's/,/ /g')
+    else
+	releases=$(get_dist_releases)
+    fi
+
+    for release in $releases ; do
+	stop_container --release="$release"
+    done
+}
+
+main

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -40,6 +40,9 @@ exit_handler() {
     rm -rf "$local_tmp_dir"
 }
 
+echo ""
+echo "Command: pwx_test_kernel_pkgs_one_container.sh $*"
+
 while [[ $# -gt 0 ]] ; do
     case "$1" in
 	--arch=* ) arch=${1#--arch=} ;;
@@ -91,8 +94,6 @@ local_tmp_dir=/tmp/test-kernels.ubuntu.$$
 test_kernel_pkgs() {
     local result local
     local release="$distro_release"
-
-    echo "Command: pwx_test_kernel_pkgs_one_container.sh $*"
 
     echo "test_kernel_pkgs: Attempting to test kernel package(s) on distribution $distro, release $release, make_args=$make_args."
 


### PR DESCRIPTION
The most consequential change in these commits is that PATH is now explicitly set in calls into LXC containers that are used for executing the tests.  Previously, PATH was being inherited from the caller's environement, and the path that was passed by cron did not include any of the sbin directories (/usr/local/sbin, /usr/sbin, and /sbin).  Those sbin directories contained important commands such as "ip" and "ldconfig".  This lead to package installation scripts breaking for Debian-based distributions and container initialization taking longer than necessary (because the "ip" command was being used to test for when networking configuration had completed).

There are many other changes, mostly clean ups to log messages, but also two bug fixes where I had declared an incorrect function name (a Fedora function in a Centos header, or something like that).