### PR TITLE
Silence some warnings for conditions that are not problems

### DIFF
--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -23,14 +23,20 @@ install_ftpd_ubuntu:
 	sed -e 's|^anonymous$$|# anonymous|' -i /etc/ftpusers
 	mkdir -p ~ftp/bin
 	cp /bin/ls ~ftp/bin/
-	ldd /bin/ls | egrep ' => /' | \
-	    ( sed 's/^.* => //;s/(0x[0-9a-f]*) *$$//' ; \
-	      echo /lib/ld-linux.so.2 ; \
-	      echo /lib64/ld-linux-x86-64.so.2 ; \
-	      echo /etc/passwd ; \
-	      echo /etc/group ; \
-	      echo /etc/nsswitch.conf ; \
-	      echo /lib/x86_64-linux-gnu/libnss_files.so.* ) | \
+	ldd /bin/ls | egrep ' => /' | ( \
+	    sed 's/^.* => //;s/(0x[0-9a-f]*) *$$//' ; \
+	    for file in \
+		/lib/ld-linux.so.2 \
+		/lib64/ld-linux-x86-64.so.2 \
+	 	/etc/passwd \
+		/etc/group \
+		/etc/nsswitch.conf \
+	        /lib/x86_64-linux-gnu/libnss_files.so.* \
+	    ; do \
+		if [ -e "$$file" ] ; then \
+		    echo "$$file" ; \
+		fi ; \
+	      done ) | \
 	    ( cd / && xargs -- tar --create --dereference ) | \
 	    ( cd ~ftp && tar xp )
 

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -80,7 +80,9 @@ install_docker: install_docker_ubuntu
 
 install_pxdev_ubuntu: install_docker_ubuntu
 	apt-get install -y git
-	- ( cd ${scriptsdir} && git clone git://github.com/portworx/px-dev.git )
+#	- ( cd ${scriptsdir} && git clone git://github.com/portworx/px-dev.git )
+# ^^^ For now, do not create /home/portworx/px-dev, but this may return
+# later, for testing in a a px-dev Docker container.
 
 install_pxdev: install_pxdev_ubuntu
 

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -24,7 +24,13 @@ install_ftpd_ubuntu:
 	mkdir -p ~ftp/bin
 	cp /bin/ls ~ftp/bin/
 	ldd /bin/ls | egrep ' => /' | \
-	    ( sed 's/^.* => //;s/(0x[0-9a-f]*) *$$//' ; echo /lib/ld-linux.so.2  ; echo /lib64/ld-linux-x86-64.so.2 ; echo /etc/passwd ; echo /etc/group ; echo /etc/nsswitch.conf ; echo /lib/x86_64-linux-gnu/libnss_files.so.* ) | \
+	    ( sed 's/^.* => //;s/(0x[0-9a-f]*) *$$//' ; \
+	      echo /lib/ld-linux.so.2 ; \
+	      echo /lib64/ld-linux-x86-64.so.2 ; \
+	      echo /etc/passwd ; \
+	      echo /etc/group ; \
+	      echo /etc/nsswitch.conf ; \
+	      echo /lib/x86_64-linux-gnu/libnss_files.so.* ) | \
 	    ( cd / && xargs -- tar --create --dereference ) | \
 	    ( cd ~ftp && tar xp )
 

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -100,7 +100,7 @@ pkgs_update_deb()       {
 dist_clean_up_container_deb()
 {
     in_container_flock_deb sh -c "
-	pkgs=\$( dpkg --list 'linux-headers-*' |
+	pkgs=\$( dpkg --list 'linux-headers-*' 2> /dev/null |
             awk '\$1 != \"un\" {print \$2;}' |
             egrep '^linux-headers-' )
         if [ -n \"\$pkgs\" ] ; then

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -33,7 +33,7 @@ in_container_flock_deb() {
 
 dist_start_container_deb()
 {
-    if in_container_flock_deb apt-get install --quiet --quiet --yes --allow-downgrades bash ; then
+    if in_container_flock_deb sh -c "apt-get install --quiet --quiet --yes --allow-downgrades bash 2> /dev/null" ; then
 	deb_apt_get_args="--quiet --quiet --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages"
     else
 	deb_apt_get_args="--quiet --quiet --yes --force-yes"

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -28,8 +28,11 @@ install_crontab() {
 	crontab -u root -
 }
 
-apt-get install --yes --quiet rpm
-# Needed for Centos support, for extracting information from .rpm files.
+apt-get install --yes --quiet git rpm
+# git is used by pwx_run_mirrors_in_script to clone px-fuse in a working
+# directory if it is provided.
+#
+# rpm is needed for Centos support, for extracting information from .rpm files.
 
 mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}/pxfuse/by-checksum"
 

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -6,7 +6,9 @@ log_file=/var/log/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.log
 
 mkdir -p "${log_file%/*}"
 
-mv --force "$log_file" "${log_file}.old"
+if [ -e "$log_file" ] ; then
+    mv --force "$log_file" "${log_file}.old"
+fi
 exec > "$log_file" 2>&1 < /dev/null
 
 PATH=/usr/local/bin:$PATH

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -146,6 +146,11 @@ done # for dir (distribution) in...
 
 output_html_trailer >> test_report/test_report.html
 
+# In addition to recording a summary to test_report/test_report.txt, also
+# write it to standard output, for cases where this script is invoked by
+# Jenkins.
+cat test_report/test_report.txt
+
 if [[ -n "$regression_distros" ]] ; then
     regression_detected $regression_distros
 fi

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -141,6 +141,7 @@ for dir in */ ; do
 	echo "<A href=\"${distribution}/${word}.html\"> $count ${word}</A>," \
 	     >> test_report/test_report.html
     done # for word in ...
+    echo "" >> test_report/test_report.txt
     ( echo "" ; echo "</P>" ) >> test_report/test_report.html
 done # for dir (distribution) in...
 


### PR DESCRIPTION
These changes silence some warning messages that are generated in normal operation that I was ignoring but which can cause confusion or at least waste time of someone reading the logs.  They also add a text output status report for the script used by cron and Jenkins (the output is only useful for Jenkins).