### PR TITLE
Fixes for cron script output and a symlink tree problem, clean up output, clean up generation of apt-get commands

### DIFF
--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -17,6 +17,11 @@ copy_link_tree_remove_index_html()
     set +e
     symlinks -d "${to}"
 
+    # Remove "$from" and/or "$to" if either one is not a directory.  That
+    # should never happen, but apparently it somehow can.  Perhaps
+    # some install script needs to be fixed.
+    rm -f "$from" "$to" 2> /dev/null || true
+
     cp --symbolic-link --recursive --remove-destination "$from/." "$to"
     save_error
 

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -33,7 +33,10 @@ save_error()
 
 	error_code=$saved_code
 
-	echo "pwx-mirror-util.sh save_error: error in shell script detected.  Trace: " >&2
+	echo "pwx-mirror-util.sh save_error: error in shell script." >&2
+	echo "This shell function trace does not imply that the script" >&2
+	echo "has aborted.  It is just provided to make it easier to" >&2
+	echo "identify the source of the error:" >&2
 	bash_stack_trace >&2
 	echo "" >&2
     fi

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -31,6 +31,10 @@ in_container_flock_deb() {
 	"$@"
 }
 
+deb_in_container_apt_get() {
+    in_container_flock_deb $deb_apt_get_cmd "$@"
+}
+
 dist_start_container_deb()
 {
     local cmd="apt-get install --quiet --quiet --yes"
@@ -42,8 +46,8 @@ dist_start_container_deb()
 }
 
 dist_init_container_deb() {
-    in_container_flock_deb $deb_apt_get_cmd update
-    in_container_flock_deb $deb_apt_get_cmd upgrade
+    deb_in_container_apt_get update
+    deb_in_container_apt_get upgrade
     # ^^^ Skip this for binary reproducibility ??
 
     install_pkgs_deb autoconf g++ gcc git libelf-dev libssl1.0 make tar
@@ -82,13 +86,13 @@ pkg_files_to_dependencies_deb() {
 }
 
 install_pkgs_deb()      {
-    in_container_flock_deb $deb_apt_get_cmd install "$@"
+    deb_in_container_apt_get install "$@"
 }
 
 # uninstall_pkgs_deb()    { in_container_flock_deb dpkg --remove "$@" ; }
 uninstall_pkgs_deb()    {
     local pkg
-    if ! in_container_flock_deb $deb_apt_get_cmd remove "$@" ; then
+    if ! deb_in_container_apt_get remove "$@" ; then
 	for pkg in "$@" ; do
 	    in_container_flock_deb dpkg --remove --force-remove-reinstreq "$pkg"
 	done
@@ -96,7 +100,7 @@ uninstall_pkgs_deb()    {
 }
 
 pkgs_update_deb()       {
-    in_container_flock_deb $deb_apt_get_cmd update
+    deb_in_container_apt_get update
 }
 
 dist_clean_up_container_deb()
@@ -109,12 +113,12 @@ dist_clean_up_container_deb()
 	    dpkg --remove \$pkgs
         fi
     "
-    in_container_flock_deb $deb_apt_get_cmd --yes clean
+    deb_in_container_apt_get --yes clean
 }
 
 install_pkgs_dir_deb()  {
-    in_container_flock_deb $deb_apt_get_cmd --yes clean
+    deb_in_container_apt_get --yes clean
     in_container_flock_deb sh -c "dpkg --install --force-all $1/*"
-    # in_container_flock_deb $deb_apt_get_cmd --fix-broken install || true
+    # deb_in_container_apt_get --fix-broken install || true
     # ^^^ Try to install any missing dependencies.
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -42,6 +42,7 @@ dist_start_container_deb()
 
 dist_init_container_deb() {
     in_container_flock_deb apt-get update $deb_apt_get_args
+    in_container_flock_deb apt-get upgrade $deb_apt_get_args
     # ^^^ Skip this for binary reproducibility ??
 
     install_pkgs_deb autoconf g++ gcc git libelf-dev libssl1.0 make tar

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -38,8 +38,10 @@ deb_in_container_apt_get() {
 dist_start_container_deb()
 {
     local cmd="apt-get install --quiet --quiet --yes"
-    if in_container_flock_deb sh -c "$cmd --allow-downgrades bash 2> /dev/null" ; then
-	deb_apt_get_cmd="$cmd --allow-downgrades --allow-remove-essential --allow-change-held-packages"
+    local new_args="--allow-downgrades --allow-remove-essential --allow-change-held-packages"
+
+    if in_container_flock_deb sh -c "$cmd $new_args install bash 2> /dev/null" ; then
+	deb_apt_get_cmd="$cmd $new_args"
     else
 	deb_apt_get_cmd="$cmd --force-yes"
     fi

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -4,16 +4,6 @@ scriptsdir=$PWD
 
 log_file=/var/log/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.log
 
-mkdir -p "${log_file%/*}"
-
-if [ -e "$log_file" ] ; then
-    mv --force "$log_file" "${log_file}.old"
-fi
-exec > "$log_file" 2>&1 < /dev/null
-
-PATH=/usr/local/bin:$PATH
-export PATH
-
 stop_lxc_test_containers() {
     local dist="$1"
 
@@ -24,18 +14,34 @@ stop_lxc_test_containers() {
 	done
 }
 
-result=0
-for dist in centos debian fedora ubuntu ; do
-    if ! pwx_test_kernels_in_mirror --distribution="$dist" \
-	 --command-args="--leave-containers-running --containers=lxc" ; then
-	result=$?
-    fi
-    stop_lxc_test_containers "$dist"
-done
+main() {
+    local result=0
+    for dist in centos debian fedora ubuntu ; do
+	if ! pwx_test_kernels_in_mirror --distribution="$dist" \
+	     --command-args="--leave-containers-running --containers=lxc" ; then
+	    result=$?
+	fi
+	stop_lxc_test_containers "$dist"
+    done
 
-$scriptsdir/pwx_update_pxfuse_by_date.sh
+    $scriptsdir/pwx_update_pxfuse_by_date.sh
+    echo "pwx_test_kernels.cron_script.sh main: result=$result"
+    return $result
+}
+
+mkdir -p "${log_file%/*}"
+
+if [ -e "$log_file" ] ; then
+    mv --force "$log_file" "${log_file}.old"
+fi
+
+PATH=/usr/local/bin:$PATH
+export PATH
+
+main > "$log_file" 2>&1 < /dev/null
+result=$?
+
 $scriptsdir/test_report.sh
-
 echo "pwx_test_kernels.cron_script.sh: result=$result"
 
 exit $result

--- a/pwx_test_kernels_in_mirror/test_report.sh
+++ b/pwx_test_kernels_in_mirror/test_report.sh
@@ -145,6 +145,10 @@ for dir in */ ; do
     ( echo "" ; echo "</P>" ) >> test_report/test_report.html
 done # for dir (distribution) in...
 
+date=$(date)
+( echo "" ; echo "Generated $date." ) >> test_report/test_report.txt
+echo "<P>Generated $date.</P>" >> test_report/test_report.html
+
 output_html_trailer >> test_report/test_report.html
 
 # In addition to recording a summary to test_report/test_report.txt, also


### PR DESCRIPTION
This pull request fixes problems identified or through discussion with Shailvi today.

There are two actual bugs that his pull request should fix:

1. The kernel testing cron script was writing its copy of test_report.txt at the end to a log file rather than to standard output.  So, the output was not reported to Jenkins.

2. Somehow /var/www/html/mirrors was somehow being made into a symlink to /home/ftp/mirrors (or maybe vice-versa).  I added a line in the mirroring cron script to try to delete both if they are not directories, so it should not interfere with making a symbolic link tree copy.

The rest of the changes are output improvements per Shailvi's input or code clean-ups:

1. Put a note before the shell function call trace that the save_error() prints to clarify that the call trace does not indicate that the function has aborted.

2. Add a time stamp to the text of test_results.html and test_results.txt, to make it easier to notice that the file has been updated, even if the results are unchanged.

3. Add an "apt-get upgrade" (to update to the latest software) at container initialization, which I had always intended to do, but somehow I had only done an "apt-get update" (which just updates the list of latest software versions).

4. Avoid repeating some apt-get command arguments in distro_driver.deb.sh.