### PR TITLE
Guard against empty index.html files from failed retrievals, fix incorrrect .log.old file name, various cleanups

### DIFF
--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -25,11 +25,15 @@ copy_link_tree_remove_index_html()
     cp --symbolic-link --recursive --remove-destination "$from/." "$to"
     save_error
 
-    find "$to" -name index.html -print0 |
-	xargs --null --no-run-if-empty -- rm -f
+    if [[ -e "$to" ]] ; then
+	find "$to" -name index.html -print0 |
+	    xargs --null --no-run-if-empty -- rm -f
+    fi
 
-    find "$to" -type d | sort -r |
-	xargs --no-run-if-empty rmdir 2> /dev/null || true
+    if [[ -e "$to" ]] ; then
+	find "$to" -type d | sort -r |
+	    xargs --no-run-if-empty rmdir 2> /dev/null || true
+    fi
 
     symlinks -cs "$to"
     save_error

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -25,7 +25,9 @@ copy_link_tree_remove_index_html()
     cp --symbolic-link --recursive --remove-destination "$from/." "$to"
     save_error
 
-    find "$to" -name index.html -print0 | xargs --null -- rm -f
+    find "$to" -name index.html -print0 |
+	xargs --null --no-run-if-empty -- rm -f
+
     find "$to" -type d | sort -r | xargs rmdir 2> /dev/null || true
 
     symlinks -cs "$to"

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -28,7 +28,8 @@ copy_link_tree_remove_index_html()
     find "$to" -name index.html -print0 |
 	xargs --null --no-run-if-empty -- rm -f
 
-    find "$to" -type d | sort -r | xargs rmdir 2> /dev/null || true
+    find "$to" -type d | sort -r |
+	xargs --no-run-if-empty rmdir 2> /dev/null || true
 
     symlinks -cs "$to"
     save_error

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -28,11 +28,13 @@ copy_link_tree_remove_index_html()
     if [[ -e "$to" ]] ; then
 	find "$to" -name index.html -print0 |
 	    xargs --null --no-run-if-empty -- rm -f
+	save_error
     fi
 
     if [[ -e "$to" ]] ; then
 	find "$to" -type d | sort -r |
 	    xargs --no-run-if-empty rmdir 2> /dev/null || true
+	save_error
     fi
 
     symlinks -cs "$to"

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -51,6 +51,7 @@ run_all_verb_scripts()
 	logfile="$logdir/${basename}.log"
 	if [[ -e "$logfile" ]] ; then
 	    mv --force "$logfile" "${logfile}.old"
+	    save_error
 	fi
         $script > "$logfile" 2>&1
 	save_error
@@ -79,6 +80,7 @@ mkdir -p "$logdir"
 
 if [[ -e "$main_logfile" ]] ; then
     mv --force "$main_logfile" "${main_logfile}.old}"
+    save_error
 fi
 ( run_all_mirror_scripts ; run_all_test_scripts ) > "$main_logfile" 2>&1 < /dev/null
 save_error

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -79,7 +79,7 @@ run_all_test_scripts()
 mkdir -p "$logdir"
 
 if [[ -e "$main_logfile" ]] ; then
-    mv --force "$main_logfile" "${main_logfile}.old}"
+    mv --force "$main_logfile" "${main_logfile}.old"
     save_error
 fi
 ( run_all_mirror_scripts ; run_all_test_scripts ) > "$main_logfile" 2>&1 < /dev/null

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -123,7 +123,7 @@ kernel_header_packages_different() {
     local end=$2
     local start_names=$(extract_kernel_header_names "$start")
     local end_names=$(extract_kernel_header_names "$end")
-    test ".${start_names}" != ".${end_names}"
+    [[ ".${start_names}" != ".${end_names}" ]]
 }
 
 # Pick a midpoint, preferably one for which index.html has already

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -36,6 +36,20 @@ on_or_after_linux_3_10_release_date() {
     egrep '^(2013051[1-9]|201305[23]|20130[6-9]|20131|201[4-9]|2[1-9]|[3-9])'
 }
 
+# Return true if the file needs to be retrieved (that is, the file
+# is absent), but, before testing, remove the file if it is empty.
+remove_if_empty_check_if_absent()
+{
+    local file="$1"
+    if [[ -s "$file" ]] ; then
+	return 1
+    fi
+    if [[ -e "$file" ]] ; then
+	rm -f "$file"
+    fi
+    return 0
+}
+
 list_kernel_dir_urls() {
     cat "${top_dir}"/index.html\?year=* |
         extract_subdirs |
@@ -64,12 +78,20 @@ remember_kernel_header_names() {
     local index="$1"
     local url=${url_array[$index]}
     local file=$(directory_url_to_filename "$url")
-    if [[ ! -e "$file" ]] ; then
+    if remove_if_empty_check_if_absent "$file" ; then
         # echo wget $TIMESTAMPING --protocol-directories --force-directories \
         #      --quiet "$url" >&2
-        wget $TIMESTAMPING --protocol-directories --force-directories \
-	     --quiet "$url"
-	save_error
+        if wget $TIMESTAMPING --protocol-directories --force-directories \
+		--quiet "$url" ; then
+	    # The "if <condition> ; then ... true ; else ... ; fi" structure
+	    # preserves the wget exit code for save_error while still
+	    # testing it.
+	    true
+	else
+	    save_error
+	    rm "$file"
+	    return 1
+	fi
     fi
     kernel_header_names[$index]=$( extract_subdirs < "$file" |
 				   linux_headers_after_3_9 )
@@ -87,12 +109,11 @@ skip_directory_urls_already_mirrored() {
     local url url_type url_rest filename
     while read url ; do
         filename=$(directory_url_to_filename "$url")
-        if [[ ! -e "$filename" ]] ; then
+	if remove_if_empty_check_if_absent "$filename" ; then
             echo "$url"
         fi
     done
 }
-
 
 # Mirror all index.html files in url_array in the inclusive range
 # [start,end] that are different.
@@ -122,7 +143,7 @@ pick_a_midpoint() {
                [[ "$guess" -lt "$end" ]] ; then
 	    
 		filename=$(directory_index_to_filename $guess)
-		if [[ -e "$filename" ]] ; then
+		if [[ -s "$filename" ]] ; then
                     echo "pick_a_midpoint: cached guess $start < $guess < $end" >&2
                     echo "$guess"
                     return 0
@@ -232,7 +253,7 @@ list_first_relative_paths() {
 skip_existing_filenames() {
     local filename
     while read filename ; do
-	if [[ ! -e "$filename" ]] ; then
+	if remove_if_empty_check_if_absent "$filename" ; then
 	    echo "$filename"
 	fi
     done


### PR DESCRIPTION
The most important changes in this batch are to mirror-kernels.debian.sh to deal with the results of a failed wget command (which I have seen in the logs) possibly leaving an incorrectly empty index.html file (which I have also found).  One patch detects the wget failure, but it's inconvenient to test that in some other cases, so the cases where these index.html files are used are changed to remove empty index.html files.  I believe that in none of those cases can an empty index.html be vailid (because empty directories result in an index.html file that still has some contents in it).

The other bug fix is for a place were a .log file was being renamed to have the extension ".log.old}" instead of ".log.old".

The other changes are clean-ups to avoid some misleading error messages that I observed in the logs.

