### PR TITLE
Fix Debian mirroring problems, genererate http://mirrors.portworx.com/build-results/for_installer/... px.ko files, other clean-ups

### DIFF
--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -41,7 +41,7 @@ install_ftpd_ubuntu:
 	    ( cd ~ftp && tar xp )
 
 install_httpd_ubuntu:
-	apt-get install -y apache2
+	apt-get install --quiet --yes apache2
 	-rm -f /var/www/html/mirrors
 	-mkdir -p /var/www/html/mirrors
 	chown -R pwxmirror /var/www/html/mirrors

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -43,10 +43,8 @@ install_ftpd_ubuntu:
 install_httpd_ubuntu:
 	apt-get install -y apache2
 	-rm -f /var/www/html/mirrors
-	if [ ! -L /var/www/html/mirrors -a ! -e /var/www/html/mirrors ] ; then \
-		( . ${scriptsdir}/pwx-mirror-config.sh && \
-		ln -s $$mirrordir /var/www/html/mirrors ) ; \
-	fi
+	-mkdir -p /var/www/html/mirrors
+	chown -R pwxmirror /var/www/html/mirrors
 	mv /var/www/html/index.html /var/www/html/index.html.orig 2> /dev/null || true
 
 install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_ubuntu

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -17,12 +17,18 @@ copy_link_tree_remove_index_html()
     set +e
     symlinks -d "${to}"
 
-    # Remove "$from" and/or "$to" if either one is not a directory.  That
-    # should never happen, but apparently it somehow can.  Perhaps
-    # some install script needs to be fixed.
-    rm -f "$from" "$to" 2> /dev/null || true
+    # Remove "$from" if is not a directory.  That should never happen,
+    # but apparently it somehow can.
+    rm -f "$from" 2> /dev/null || true
 
-    cp --symbolic-link --recursive --remove-destination "$from/." "$to"
+    # For some reason, the recursive copy does not seem to update some of
+    # the subdirectories incrementally.  So, remove the target tree and
+    # remake all of the symbolic links.
+    rm -rf "$to.new" 2> /dev/null || true
+    cp --symbolic-link --recursive --remove-destination "$from/." "$to.new"
+    save_error
+    rm -rf "$to"
+    mv "$to.new" "$to"
     save_error
 
     if [[ -e "$to" ]] ; then

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -24,11 +24,8 @@ copy_link_tree_remove_index_html()
     # For some reason, the recursive copy does not seem to update some of
     # the subdirectories incrementally.  So, remove the target tree and
     # remake all of the symbolic links.
-    rm -rf "$to.new" 2> /dev/null || true
-    cp --symbolic-link --recursive --remove-destination "$from/." "$to.new"
-    save_error
-    rm -rf "$to"
-    mv "$to.new" "$to"
+    rm -rf "$to" 2> /dev/null || true
+    cp --symbolic-link --recursive --remove-destination "$from/." "$to"
     save_error
 
     if [[ -e "$to" ]] ; then

--- a/portworx-mirror-server/cron-script.sh
+++ b/portworx-mirror-server/cron-script.sh
@@ -76,12 +76,13 @@ run_all_test_scripts()
     true
 }
 
-mkdir -p "$logdir"
-
 if [[ -e "$main_logfile" ]] ; then
     mv --force "$main_logfile" "${main_logfile}.old"
     save_error
+else
+    mkdir -p "$logdir"
 fi
+
 ( run_all_mirror_scripts ; run_all_test_scripts ) > "$main_logfile" 2>&1 < /dev/null
 save_error
 

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -328,8 +328,8 @@ mirror_debian()
     local top_url="$1"
     local top_dir=$(url_to_dir "$top_url")
     # Uncomment one of the following two lines:
-    # local mirror_kernel_dir_indexes=mirror_kernel_dir_index_files_binary_search
-    local mirror_kernel_dir_indexes=mirror_kernel_dir_index_files_all
+    local mirror_kernel_dir_indexes=mirror_kernel_dir_index_files_binary_search
+    # local mirror_kernel_dir_indexes=mirror_kernel_dir_index_files_all
 
     rename_bad_deb_files "$top_dir"
     mirror_top_level_directories "$top_url"

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -233,9 +233,7 @@ list_kernel_filenames_plus_directories() {
     local top_dir="$1"
     local subdir="$2"	# For example "/pool/main/l/linux-tools/"
     local index_filename pkg_filename dir 
-    for index_filename in \
-	"${top_dir}"/*/"${subdir}/index.html" \
-    do
+    for index_filename in "${top_dir}"/*/"${subdir}/index.html" ; do
 	dir=${index_filename%/index.html}
 	extract_subdirs < "$index_filename" |
 	    linux_headers_after_3_9 |

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -178,7 +178,7 @@ binary_search() {
     local end="$3"
     local mid result
 
-    shift 2
+    shift 3
 
     if ! "$@" "$start" "$end" ; then
         result=$?

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -129,7 +129,7 @@ kernel_header_packages_different() {
 	echo "    url_array[start]=${url_array[$start]}." >&2
 	echo "    url_array[end]=${url_array[$end]}." >&2
 	echo "    start_names=$start_names." >&2
-	echo "    end_names=$end_names." >&2
+	# echo "    end_names=$end_names." >&2
     fi
     return $result
 }

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -337,5 +337,6 @@ mirror_debian()
 }
 
 mirror_debian "http://snapshot.debian.org/archive/debian"
+mirror_debian "http://security.debian.org/debian-security"
 
 exit $error_code

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -343,6 +343,11 @@ mirror_debian()
 }
 
 mirror_debian "http://snapshot.debian.org/archive/debian"
-mirror_debian "http://security.debian.org/debian-security"
+# mirror_debian "http://security.debian.org/debian-security"
+# ^^^ Does not mirror for now, as it appears that this directory tree
+# has a slightly different layout.  We probably want
+# http://security.debian.org/debian-security/pool/updates/main/l/linux/linux-headers* ,
+# but linux-kbuild packages do not appear to be in that directory.  Perhaps
+# they are outside of the "updates" directory tree.
 
 exit $error_code

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -225,7 +225,7 @@ mirror_kernel_dir_index_files_all() {
 
     list_kernel_directories "$top_dir" |
         skip_directories_already_mirrored "$top_dir" |
-	sed "s|^(.*)\$|${top_url}\\1/" |
+	sed "s|^(.*)\$|${top_url}\\1/|" |
         xargs --no-run-if-empty -- \
             wget --quiet --protocol-directories --force-directories
 

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -349,12 +349,17 @@ mirror_debian()
     done
 }
 
+mirror_security_debian_org()
+{
+    # FIXME?  linux-kbuild packages do not appear to be in this directory.
+    # What other directory needs to be mirrored or searched?
+    wget $TIMESTAMPING --protocol-directories --force-directories \
+	 --mirror --level=1 \
+         --accept-regex="/linux-(headers|compiler|kbuild).*_${arch}\.deb\$" \
+	 http://security.debian.org/debian-security/pool/updates/main/l/linux/
+}
+
 mirror_debian "http://snapshot.debian.org/archive/debian"
-# mirror_debian "http://security.debian.org/debian-security"
-# ^^^ Does not mirror for now, as it appears that this directory tree
-# has a slightly different layout.  We probably want
-# http://security.debian.org/debian-security/pool/updates/main/l/linux/linux-headers* ,
-# but linux-kbuild packages do not appear to be in that directory.  Perhaps
-# they are outside of the "updates" directory tree.
+mirror_security_debian_org
 
 exit $error_code

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -187,7 +187,7 @@ test_kernel_pkgs_func() {
 
 	    guess_utsname=${headers_dir#/usr/src/}
 	    guess_utsname=${guess_utsname#kernels/}
-	    guess_utsname=${guess_utsname#linux-header-}
+	    guess_utsname=${guess_utsname#linux-headers-}
 
 	    pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -112,7 +112,7 @@ test_kernel_pkgs_func() {
     local result filename real dirname basename headers_dir
     local pkg_names deps_unfiltered dep_names arg guess_utsname dir
     local container_tmpdir=/tmp/test-portworx-kernels.$$
-    local pxfuse_dir
+    local pxfuse_dir pxd_version
     local make_args=
 
     for arg in "$@" ; do
@@ -187,7 +187,10 @@ test_kernel_pkgs_func() {
 	    guess_utsname=${headers_dir#/usr/src/}
 	    guess_utsname=${guess_utsname#kernels/}
 	    guess_utsname=${guess_utsname#linux-header-}
-	    dir="/home/ftp/build-results/pxfuse/for-installer/$guess_utsname"
+
+	    pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
+
+	    dir="${for_installer_dir}/${pxd_version}/${guess_utsname}"
 	    rm -rf "$dir/packages"
 	    mkdir -p "$dir/packages"
 	    ln --symbolic --force "$@" "$dir/packages/"

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -26,6 +26,7 @@ EOF
 . ${scriptsdir}/container_driver.sh
 . ${scriptsdir}/distro_driver.sh
 
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64"
 arch=amd64
 distro=ubuntu
 distro_release=""

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -188,6 +188,7 @@ test_kernel_pkgs_func() {
 	    guess_utsname=${guess_utsname#kernels/}
 	    guess_utsname=${guess_utsname#linux-header-}
 	    dir="/home/ftp/build-results/pxfuse/for-installer/$guess_utsname"
+	    rm -rf "$dir/packages"
 	    mkdir -p "$dir/packages"
 	    ln --symbolic --force "$@" "$dir/packages/"
 	    symlinks -c "$dir/packages" > /dev/null

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -110,7 +110,7 @@ filter_word() {
 test_kernel_pkgs_func() {
     local container_tmpdir result_logdir
     local result filename real dirname basename headers_dir
-    local pkg_names deps_unfiltered dep_names arg
+    local pkg_names deps_unfiltered dep_names arg guess_utsname dir
     local container_tmpdir=/tmp/test-portworx-kernels.$$
     local pxfuse_dir
     local make_args=
@@ -183,6 +183,16 @@ test_kernel_pkgs_func() {
 	if [[ "$result" = 0 ]] ; then
 	    in_container tar -C "${container_tmpdir}/pxfuse_dir" -c px.ko |
 		tar -C "${result_logdir}" -xpv
+
+	    guess_utsname=${headers_dir#/usr/src/}
+	    guess_utsname=${guess_utsname#kernels/}
+	    guess_utsname=${guess_utsname#linux-header-}
+	    dir="/home/ftp/build-results/pxfuse/for-installer/$guess_utsname"
+	    mkdir -p "$dir/packages"
+	    ln --symbolic --force "$@" "$dir/packages/"
+	    symlinks -c "$dir/packages" > /dev/null
+	    cp "${result_logdir}/px.ko" "$dir/"
+
 	fi # result = 0
 	touch "${result_logdir}/ran_test"
     fi # result = 0

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -26,7 +26,7 @@ EOF
 . ${scriptsdir}/container_driver.sh
 . ${scriptsdir}/distro_driver.sh
 
-for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64"
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64/version"
 arch=amd64
 distro=ubuntu
 distro_release=""

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -3,6 +3,7 @@
 prefix=/usr/local
 scriptsdir=${prefix}/share/pwx_test_kernels_in_mirror/scripts
 build_results_dir=/home/ftp/build-results
+downloads_dir=/home/ftp/downloads
 bindir=${prefix}/bin
 
 set -e
@@ -56,5 +57,10 @@ chmod a+x \
 #
 # install_crontab
 
-rm -f /var/www/html/build-results
-ln -s ${build_results_dir} /var/www/html/build-results
+for dist in centos debian fedora ubuntu ; do
+    mkdir -p "${downloads_dir}/${dist}"
+done
+
+rm -f /var/www/html/build-results /var/www/html/downloads
+ln -s "$build_results_dir" /var/www/html/build-results
+ln -s "$downloads_dir" /var/www/html/downloads

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -40,6 +40,7 @@ mkdir -p "${scriptsdir}" "${bindir}" "${build_results_dir}/pxfuse/by-checksum"
 install_scripts "${scriptsdir}" \
 		mirror_walk_driver.*.sh \
 		mirror_walk_driver.sh \
+		pwx_export_results_for_installer.sh \
 		pwx_test_kernels.cron_script.sh \
 		pwx_update_pxfuse_by_date.sh \
 		test_report.sh
@@ -48,6 +49,7 @@ install_scripts "${bindir}" pwx_test_kernels_in_mirror
 
 chmod a+x \
       "${bindir}/pwx_test_kernels_in_mirror" \
+      "${scriptsdir}/pwx_export_results_for_installer.sh" \
       "${scriptsdir}/pwx_test_kernels.cron_script.sh" \
       "${scriptsdir}/pwx_update_pxfuse_by_date.sh" \
       "${scriptsdir}/test_report.sh"

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.debian.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.debian.sh
@@ -9,6 +9,7 @@ debian_find_txt="${debian_tmpdir}/find.sorted.txt"
 get_default_mirror_dirs_debian()
 {
     echo /home/ftp/mirrors/http/snapshot.debian.org/archive/debian
+    echo /home/ftp/mirrors/http/security.debian.org/debian-security
 }
 
 pkg_files_to_names_debian()       { pkg_files_to_names_deb        "$@" ; }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -12,6 +12,11 @@
 # Used for selecting kernels version 3.10 or later.  Used by some drivers.
 above_3_9_regexp='(3\.[1-9][0-9]+|[4-9][0-9]*|[1-9][0-9]+)(\.[.0-9]+[0-9])?'
 
-get_default_mirror_dirs()  { "get_default_mirror_dirs_$distro"  "$@" ; }
 pkg_files_to_names()       { "pkg_files_to_names_$distro"       "$@" ; }
 walk_mirror()              { "walk_mirror_$distro"              "$@" ; }
+
+get_default_mirror_dirs()
+{
+    "get_default_mirror_dirs_$distro""$@"
+    echo "/home/ftp/downloads/$distro"
+}

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -66,7 +66,7 @@ guess_utsname=$(egrep 'make KERNELPATH=' < "$logdir/build.log" |
 		       sed 's/^.* KERNELPATH=//;s/ .*//' | sort -u)
 guess_utsname=${guess_utsname#/usr/src/}
 guess_utsname=${guess_utsname#kernels/}
-guess_utsname=${guess_utsname#linux-header-}
+guess_utsname=${guess_utsname#linux-headers-}
 
 pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
 

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+scriptsdir=$PWD
+
+for_installer_dir="/home/ftp/build-results/pxfuse-for-installer"
+
+usage()
+{
+    cat <<EOF
+Usage:
+        pwx_export_results_for_installer --recursive
+		...or...
+        pwx_export_results_for_installer [--logdir=... and other args
+                accepted by pwx_test_kernel_pkgs] pkg_files...
+
+The "--recursive" usage is probably normally the only one you want to invoke.
+It calls pwx_export_results_for_install.sh via pwx_test_kernels_in_mirror for
+a set of known distributions (currently, CentOS, Debian, Fedora, and Ubuntu).
+
+pxw_export_results_for_install.sh installs directories in
+${for_installer_dir} based
+on the latest build results in /home/ftp/build-results/pxfuse.
+
+EOF
+}
+
+logdir=
+
+if [[ $# -eq 0 ]] ; then
+    usage
+    exit 0
+fi
+
+if [[ $# -eq 1 ]] && [[ ".$1" = ".--recursive" ]] ; then
+    for dist in centos debian fedora ubuntu ; do
+	pwx_test_kernels_in_mirror --distribution="$dist" \
+	   --command-args="--command=$0"
+	symlinks -c "$for_installer_dir"
+    done
+fi
+
+while [[ $# -gt 0 ]] ; do
+    case "$1" in
+	--  ) shift ; break ;;
+	--logdir=* ) logdir=${1#--logdir=} ;;
+	--* ) shift ;;
+	* ) break ;;
+    esac
+done
+
+set -e
+[[ -e "$logdir/exit_code" ]]
+read exit_code rest < "$logdir/exit_code"
+guess_utsname=$(egrep 'make KERNELPATH=' < "$logdir/build.log" |
+		       sed 's/^.* KERNELPATH=//;s/ .*//')
+guess_utsname=${guess_utsname#kernels/}
+guess_utsname=${guess_utsname#linux-header-}
+dir="${for_installer_dir}/${guess_utsname}"
+mkdir -p "$dir/packages"
+ln --symbolic --force "$@" "$dir/packages/"
+# symlinks -c "$dir/packages" > /dev/null
+cp "${result_logdir}/px.ko" "$dir/"

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -43,9 +43,10 @@ while [[ $# -gt 0 ]] ; do
     case "$1" in
 	--  ) shift ; break ;;
 	--logdir=* ) logdir=${1#--logdir=} ;;
-	--* ) shift ;;
+	--* ) ;;
 	* ) break ;;
     esac
+    shift
 done
 
 set -e

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -2,7 +2,7 @@
 
 scriptsdir=$PWD
 
-for_installer_dir="/home/ftp/build-results/pxfuse-for-installer"
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer"
 
 usage()
 {
@@ -49,9 +49,18 @@ while [[ $# -gt 0 ]] ; do
     shift
 done
 
-set -e
-[[ -e "$logdir/exit_code" ]]
-read exit_code rest < "$logdir/exit_code"
+if [[ ! -e "$logdir/exit_code" ]] ; then
+    exit 0
+fi
+
+if ! read exit_code rest < "$logdir/exit_code" ; then
+    exit $?
+fi
+
+if [[ ".$exit_code" != ".0" ]] ; then
+    exit 0
+fi
+
 guess_utsname=$(egrep 'make KERNELPATH=' < "$logdir/build.log" |
 		       sed 's/^.* KERNELPATH=//;s/ .*//')
 guess_utsname=${guess_utsname#kernels/}

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -36,6 +36,7 @@ if [[ $# -eq 1 ]] && [[ ".$1" = ".--recursive" ]] ; then
 	pwx_test_kernels_in_mirror --distribution="$dist" --command="$0"
 	symlinks -c "$for_installer_dir"
     done
+    exit $?
 fi
 
 while [[ $# -gt 0 ]] ; do

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -25,6 +25,7 @@ EOF
 }
 
 logdir=
+pxfuse_dir=
 
 if [[ $# -eq 0 ]] ; then
     usage
@@ -43,6 +44,7 @@ while [[ $# -gt 0 ]] ; do
     case "$1" in
 	--  ) shift ; break ;;
 	--logdir=* ) logdir=${1#--logdir=} ;;
+	--pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
 	--* ) ;;
 	* ) break ;;
     esac
@@ -62,12 +64,16 @@ if [[ ".$exit_code" != ".0" ]] ; then
 fi
 
 guess_utsname=$(egrep 'make KERNELPATH=' < "$logdir/build.log" |
-		       sed 's/^.* KERNELPATH=//;s/ .*//')
+		       sed 's/^.* KERNELPATH=//;s/ .*//' | sort -u)
+guess_utsname=${guess_utsname#/usr/src/}
 guess_utsname=${guess_utsname#kernels/}
 guess_utsname=${guess_utsname#linux-header-}
-dir="${for_installer_dir}/${guess_utsname}"
+
+pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
+
+dir="${for_installer_dir}/${pxd_version}/${guess_utsname}"
 rm -rf "$dir/packages"
 mkdir -p "$dir/packages"
 ln --symbolic --force "$@" "$dir/packages/"
 # symlinks -c "$dir/packages" > /dev/null
-cp "${result_logdir}/px.ko" "$dir/"
+cp "${logdir}/px.ko" "$dir/"

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -66,6 +66,7 @@ guess_utsname=$(egrep 'make KERNELPATH=' < "$logdir/build.log" |
 guess_utsname=${guess_utsname#kernels/}
 guess_utsname=${guess_utsname#linux-header-}
 dir="${for_installer_dir}/${guess_utsname}"
+rm -rf "$dir/packages"
 mkdir -p "$dir/packages"
 ln --symbolic --force "$@" "$dir/packages/"
 # symlinks -c "$dir/packages" > /dev/null

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -33,8 +33,7 @@ fi
 
 if [[ $# -eq 1 ]] && [[ ".$1" = ".--recursive" ]] ; then
     for dist in centos debian fedora ubuntu ; do
-	pwx_test_kernels_in_mirror --distribution="$dist" \
-	   --command-args="--command=$0"
+	pwx_test_kernels_in_mirror --distribution="$dist" --command="$0"
 	symlinks -c "$for_installer_dir"
     done
 fi

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -2,8 +2,6 @@
 
 scriptsdir=$PWD
 
-for_installer_dir="/home/ftp/build-results/pxfuse/for-installer"
-
 usage()
 {
     cat <<EOF
@@ -24,6 +22,7 @@ on the latest build results in /home/ftp/build-results/pxfuse.
 EOF
 }
 
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64"
 logdir=
 pxfuse_dir=
 

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -22,7 +22,7 @@ on the latest build results in /home/ftp/build-results/pxfuse.
 EOF
 }
 
-for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64"
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64/version"
 logdir=
 pxfuse_dir=
 

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -29,10 +29,10 @@ main() {
     return $result
 }
 
-mkdir -p "${log_file%/*}"
-
 if [ -e "$log_file" ] ; then
     mv --force "$log_file" "${log_file}.old"
+else
+    mkdir -p "${log_file%/*}"
 fi
 
 PATH=/usr/local/bin:$PATH

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
@@ -98,6 +98,13 @@ mirror_callback() {
 	pkg_subdir=${pkg1#$mirror_dir}
     fi
 
+    if [[ ".$pkg_subdir" = ".$pkg1" ]] ; then
+	# If the previous commands did not chop anything else off, at
+	# least try to remove the leading "/home/ftp/".  This is for
+	# packages found in /home/ftp/downloads/<distribution>/.
+	pkg_subdir="${pkg1#/home/ftp/}"
+    fi
+
     shift 2
 
     command_logdir="${log_subdir}/${pkg_subdir}"


### PR DESCRIPTION
This description is based an email I sent a day ago, but has been heavily edited to reflect many changes since then.

1. I fixed the Debian mirroring problem by having the relevant mirror script do its binary search for changed directories separately for each subdirectory (currently "linux" and "linux-tools").  This appears to have been the cause of many problems with Debian, where the mirror-script would decide that if there were no changes to "linux-tools" in a certain time range, then there must not have been any changes to the "linux" subdirectories.  I am currently running the updated software for an initial test on a virtual machine running on my home computer.  I expect that later today I will either have more changes to push or be able to claim that it works.  I have also committed many other clean-ups and some fixes (mostly to those clean-ups), and have also switched the mirror script not to do a binary search anymore, but instead just mirror all of the index.html files for the directories that could possibly have packages files that would be needed by the build (linux-headers, linux-kbuild, linux-compiler-gcc).

2. I changed the Debian mirroring code to support multiple repositories and tried to add security.debian.org, per Jose's suggestion, but that the updates section of that repository appears to lack linux-kbuild files.  So, making that work is not so easy.  So, I have left in a commented out line for mirrroring the relevant part of security.debian.org that does not quite work yet, and I have left in place code in the build scripts so that if security.debian.org is ever mirrorred, the build scripts should try to compile the files, although it will be probably be necessary to teach the test scripts where to find the matching linux-kbuild files if they are published at all.

3. I changed the kernel testing script (pwx_test_kernel_pkgs_one_container.sh) so when a build is successful, the resulting px.ko file is copies to a directory visible as http://mirrors.portworx.com/build-results/pxfuse/for-installer/<portworx-driver-version>/<kernel-version>/px.ko.  I believe that <portworx-driver-version> is currently "3".  In each of these directories, it also creates a "packages" subdirectory, containing symbolic links to the installed packages.  I am using symbolic links because these directories will, in aggregate, basically contain a second copy of all of the packages in ~ftp/mirrors, currently totally about 15 gigabytes.  The storage space currently provisioned on portworx is about 61GB, of which 41GB is still available, so I should be able to make copies instead of symbolic links, but I would rather use symbolic links at least for now just for faster testing.

4. I added a new script that attempts to generate the "for-installer" directory without from the results of the kernel tests without rerunning the kernel tests.  Currently, it installs the px.ko files, but misses some of the packages, because of the additional packages are generated in pwx_test_kernel_pkgs.sh.  This script is not used by anything other than itself.  It is basically just a quick way to populate the px.ko files until all tests are rerun.  You can see the results by visiting http://mirrors.portworx.com/build-results/pxfuse/for-installer/ , and this should be usable for testing changes to the Portworx installation scripts to try this.