### PR TITLE
Rearrange paths for downloading resulting px.ko files and package files per suggestion by Jose

### DIFF
--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -26,7 +26,7 @@ EOF
 . ${scriptsdir}/container_driver.sh
 . ${scriptsdir}/distro_driver.sh
 
-for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64/version"
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64"
 arch=amd64
 distro=ubuntu
 distro_release=""
@@ -111,7 +111,8 @@ filter_word() {
 test_kernel_pkgs_func() {
     local container_tmpdir result_logdir
     local result filename real dirname basename headers_dir
-    local pkg_names deps_unfiltered dep_names arg guess_utsname dir
+    local pkg_names deps_unfiltered dep_names arg guess_utsname
+    local export_dir export_pkgs_dir export_module_dir
     local container_tmpdir=/tmp/test-portworx-kernels.$$
     local pxfuse_dir pxd_version
     local make_args=
@@ -191,12 +192,16 @@ test_kernel_pkgs_func() {
 
 	    pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
 
-	    dir="${for_installer_dir}/${pxd_version}/${guess_utsname}"
-	    rm -rf "$dir/packages"
-	    mkdir -p "$dir/packages"
-	    ln --symbolic --force "$@" "$dir/packages/"
-	    symlinks -c "$dir/packages" > /dev/null
-	    cp "${result_logdir}/px.ko" "$dir/"
+	    export_dir="${for_installer_dir}/${guess_utsname}"
+	    export_pkgs_dir="${export_dir}/packages"
+	    export_module_dir="${export_dir}/version/${pxd_version}"
+
+	    rm -rf "$export_pkgs_dir" "$export_module_dir"
+	    mkdir -p "$export_pkgs_dir" "$export_module_dir"
+	    ln --symbolic --force "$@" "${export_pkgs_dir}/"
+	    symlinks -c "$export_pkgs_dir" > /dev/null
+
+	    cp "${result_logdir}/px.ko" "${export_module_dir}/"
 
 	fi # result = 0
 	touch "${result_logdir}/ran_test"

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -22,7 +22,7 @@ on the latest build results in /home/ftp/build-results/pxfuse.
 EOF
 }
 
-for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64/version"
+for_installer_dir="/home/ftp/build-results/pxfuse/for-installer/x86_64"
 logdir=
 pxfuse_dir=
 
@@ -33,7 +33,8 @@ fi
 
 if [[ $# -eq 1 ]] && [[ ".$1" = ".--recursive" ]] ; then
     for dist in centos debian fedora ubuntu ; do
-	pwx_test_kernels_in_mirror --distribution="$dist" --command="$0"
+	cmd=$(realpath "$0")
+	pwx_test_kernels_in_mirror --distribution="$dist" --command="$cmd"
 	symlinks -c "$for_installer_dir"
     done
     exit $?
@@ -70,9 +71,13 @@ guess_utsname=${guess_utsname#linux-headers-}
 
 pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
 
-dir="${for_installer_dir}/${pxd_version}/${guess_utsname}"
-rm -rf "$dir/packages"
-mkdir -p "$dir/packages"
-ln --symbolic --force "$@" "$dir/packages/"
-# symlinks -c "$dir/packages" > /dev/null
-cp "${logdir}/px.ko" "$dir/"
+export_dir="${for_installer_dir}/${guess_utsname}"
+export_pkgs_dir="${export_dir}/packages"
+export_module_dir="${export_dir}/version/${pxd_version}"
+
+rm -rf "$export_pkgs_dir" "$export_module_dir"
+mkdir -p "$export_pkgs_dir" "$export_module_dir"
+ln --symbolic --force "$@" "${export_pkgs_dir}/"
+symlinks -c "$export_pkgs_dir" > /dev/null
+
+cp "${logdir}/px.ko" "${export_module_dir}/"


### PR DESCRIPTION
This change rearranges the paths for downloading px.ko files generated by the build test so that package files can be shared across $PXMOD_VERSION numbers (although they are just symbolic links at this point).  I think this change is best explained by the following excerpt from Jose's email.  So, I'll just append it here. --Adam

[...]
I was wondering if we could make a change of moving the packages or adding a link to packages up outside of the version location.    Since the build packages should not differ between versions can we access them independent of the version?

So for e.g.  kernel version: 3.16.0-4-amd64  we have packages at the following location

http://mirrors.portworx.com/build-results/pxfuse/for-installer/x86_64/version/3/3.16.0-4-amd64/packages/

Since the packages are independent of the version can we have them location at 

http://mirrors.portworx.com/build-results/pxfuse/for-installer/x86_64/3.16.0-4-amd64/packages/

and have the versioned px.ko located at 

http://mirrors.portworx.com/build-results/pxfuse/for-installer/x86_64/3.16.0-4-amd64/version/3

Then scripting we can just use:  http://mirrors.portworx.com/build-results/pxfuse/for-installer/${arch}/${kernel}/packages/
[...]
