### PR TITLE
Make mirror-kernels.debian.sh remove duplicate .deb files automatically, comment out a debug message

### DIFF
--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -81,7 +81,8 @@ mirror_mirror_centos_org() {
     save_error
 }
 
-
+# TODO: Maybe add this after filtering for kernel versions 3.10 and later:
+# mirror_mirror_centos_org http://dev.centos.org/
 mirror_mirror_centos_org http://mirror.centos.org/centos/
 mirror_mirror_centos_org http://vault.centos.org/centos/
 save_error

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -92,6 +92,7 @@ mirror_mirror_centos_org http://vault.centos.org/centos/
 save_error
 
 mirror_el_repo "http://elrepo.org/linux/kernel/"
+mirror_el_repo "http://mirrors.coreix.net/elrepo-archive-archive/kernel/"
 save_error
 
 exit $error_code

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -19,6 +19,7 @@ error_code=0
 mirror_el_repo() {
     local top_url="$1"
     local top_dir=$(url_to_dir "$top_url")
+    local kernel_regexp
 
     local rpm_arch
 
@@ -41,10 +42,12 @@ mirror_el_repo() {
 
     save_error
 
+    kernel_regexp="kernel-([a-z]+-)?devel-${above_3_9_regexp}[0-9.]*-.*${rpm_arch}.rpm"
+
     for dir in ${top_dir}/*/${rpm_arch}/RPMS/ ; do
 	echo ''
 	extract_subdirs < $dir/index.html |
-	    egrep "^kernel-.*devel-.*.${rpm_arch}.rpm$" |
+	    egrep "^${kernel_regexp}\$" |
 	    subdirs_to_urls http://${dir#http/}
     done |
 	xargs -- wget --quiet --no-parent ${TIMESTAMPING} \

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -71,7 +71,12 @@ mirror_mirror_centos_org() {
 	xargs wget --quiet --no-parent ${TIMESTAMPING} -e robots=off \
 	 --protocol-directories --force-directories --recursive --level=1 \
 	 --accept-regex="/(index.html)|(kernel-.*devel.*\.rpm)"
-
+    #                                         ^^^
+    # Notice that the "--accept-regexp=..." argument is written to allow
+    # more characters between the "kernel-" and "devel", to accomodate
+    # packages name kenrel-ml-devel... and kernel-lt-devel... for
+    # "main line" and "long term" kernels.
+    #
     # FIXME.  The following regular expresion might filter out kernels before
     # 3.10.  It is modified from one that was not working, but maybe this
     # version might work.

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -16,10 +16,6 @@ TIMESTAMPING='--no-clobber --no-use-server-timestamps'
 
 error_code=0
 
-versions_above_3_9 () {
-    egrep '^v(4|3\.[1-9][0-9]).*/$'
-}
-
 mirror_el_repo() {
     local top_url=http://elrepo.org/linux/kernel/
     local top_dir=$(url_to_dir "$top_url")

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -17,7 +17,7 @@ TIMESTAMPING='--no-clobber --no-use-server-timestamps'
 error_code=0
 
 mirror_el_repo() {
-    local top_url=http://elrepo.org/linux/kernel/
+    local top_url="$1"
     local top_dir=$(url_to_dir "$top_url")
 
     local rpm_arch
@@ -88,7 +88,7 @@ mirror_mirror_centos_org http://mirror.centos.org/centos/
 mirror_mirror_centos_org http://vault.centos.org/centos/
 save_error
 
-mirror_el_repo
+mirror_el_repo "http://elrepo.org/linux/kernel/"
 save_error
 
 exit $error_code

--- a/portworx-mirror-server/mirror-kernels.centos.sh
+++ b/portworx-mirror-server/mirror-kernels.centos.sh
@@ -58,7 +58,7 @@ mirror_el_repo() {
 }
 
 mirror_mirror_centos_org() {
-    local top_url=http://mirror.centos.org/centos/
+    local top_url="$1"
     local top_dir=$(url_to_dir "$top_url")
 
     rename_bad_rpm_files "$top_dir"
@@ -82,12 +82,8 @@ mirror_mirror_centos_org() {
 }
 
 
-# TODO? mirror vault.centos.org, but it only contains source RPM's.  The
-# kernel-headers RPM's that we use are apparently non-source RPM's
-# generated from kernel source RPM's.
-
-# mirror_vault_centos_org
-mirror_mirror_centos_org
+mirror_mirror_centos_org http://mirror.centos.org/centos/
+mirror_mirror_centos_org http://vault.centos.org/centos/
 save_error
 
 mirror_el_repo

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -323,6 +323,30 @@ mirror_pkg_files() {
     save_error
 }
 
+show_duplicates_from_later_directories()
+{
+    local oldname filename filepath
+
+    oldname=
+
+    awk -F/ '{print $NF, $0}' |
+        sort |
+        while read filename filepath ; do
+            if [[ ".$filename" = ".$oldname" ]] ; then
+                echo "$filepath"
+            fi
+            oldname="$filename"
+        done
+}
+
+remove_duplicate_files()
+{
+    local top_dir="$1"
+    find "$top_dir" -name '*.deb' -type f -print |
+	show_duplicates_from_later_directories |
+	xargs --no-run-if-empty -- rm -f
+}
+
 mirror_debian()
 {
     local top_url="$1"
@@ -347,6 +371,8 @@ mirror_debian()
 	mirror_pkg_files "$top_dir" "$subdir"
 	save_error
     done
+
+    remove_duplicate_files "$top_dir"
 }
 
 mirror_security_debian_org()

--- a/portworx-mirror-server/mirror-kernels.debian.sh
+++ b/portworx-mirror-server/mirror-kernels.debian.sh
@@ -163,7 +163,7 @@ pick_a_midpoint() {
 		
 		filename=${top_dir}/$(directory_index_to_filename $guess)
 		if [[ -s "$filename" ]] ; then
-                    echo "pick_a_midpoint: cached guess $start < $guess < $end" >&2
+                    # echo "pick_a_midpoint: cached guess $start < $guess < $end" >&2
                     echo "$guess"
                     return 0
 		fi

--- a/portworx-mirror-server/pwx-mirror-util.sh
+++ b/portworx-mirror-server/pwx-mirror-util.sh
@@ -80,19 +80,23 @@ subdirs_to_urls() {
 rename_bad_pkg_files() {
     local extension="$1"
     local command="$2"
-    local file
+    local dir file
     # FIXME?  Perhaps in the future, it would be better to maintain
     # a list of files that have already been checked and only check new
     # additions most of the time.  Better yet would be to have wget
     # download files to a temporary name, and only move them into place
     # after verifying them.
     shift 2
-    find "$@" -name "*${extension}" -type f -print0 |
-	while read -r -d $'\0' file ; do
-	    if ! $command "$file" > /dev/null 2>&1 ; then
-		mv --force "$file" "${file}.corrupt"
-	    fi
-	done
+    for dir in "$@" ; do
+	if [[ -e "$dir" ]] ; then
+	    find "$dir" -name "*${extension}" -type f -print0 |
+		while read -r -d $'\0' file ; do
+		    if ! $command "$file" > /dev/null 2>&1 ; then
+			mv --force "$file" "${file}.corrupt"
+		    fi
+		done
+	fi
+    done
 }
 
 rename_bad_deb_files() {

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -10,7 +10,8 @@ get_default_mirror_dirs_centos()
     echo \
 	/home/ftp/mirrors/http/elrepo.org/linux/kernel \
 	/home/ftp/mirrors/http/mirror.centos.org/centos \
-	/home/ftp/mirrors/http/vault.centos.org/centos
+	/home/ftp/mirrors/http/vault.centos.org/centos \
+	/home/ftp/mirrors/mirrors.coreix.net/elrepo-archive-archive/kernel
 
     # echo /home/ftp/mirrors/http/dev.centos.org
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -10,6 +10,7 @@ get_default_mirror_dirs_centos()
     echo \
 	/home/ftp/mirrors/http/elrepo.org/linux/kernel \
 	/home/ftp/mirrors/http/mirror.centos.org/centos
+	/home/ftp/mirrors/http/vault.centos.org/centos
 }
 
 walk_mirror_centos() {

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -9,8 +9,10 @@ get_default_mirror_dirs_centos()
 {
     echo \
 	/home/ftp/mirrors/http/elrepo.org/linux/kernel \
-	/home/ftp/mirrors/http/mirror.centos.org/centos
+	/home/ftp/mirrors/http/mirror.centos.org/centos \
 	/home/ftp/mirrors/http/vault.centos.org/centos
+
+    # echo /home/ftp/mirrors/http/dev.centos.org
 }
 
 walk_mirror_centos() {


### PR DESCRIPTION
Make mirror-kernels.debian.sh remove duplicate .deb files automatically.  This problem might never occur, but I think it theoretically could downloading an index.html file failed in the right way or if read at just the right moment while another instance of mirror-kernels.debian.sh is running.  Probably of more practical use, this should guard against a bug still lurking that binary search code (although I am not aware of any at this point).

Also, I had forgotten to comment out a frequent debug message.  So, I made a separate commit to comment out that line too.

Edit 12/10/2016: Since making this pull request, I have pushed changes to add vault.centos.org and compile kernels from it.