### PR TITLE
Fix typo.  Missing "http/" in "/home/ftp/mirrors/http/mirrors.coreix.…

### DIFF
--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -11,7 +11,7 @@ get_default_mirror_dirs_centos()
 	/home/ftp/mirrors/http/elrepo.org/linux/kernel \
 	/home/ftp/mirrors/http/mirror.centos.org/centos \
 	/home/ftp/mirrors/http/vault.centos.org/centos \
-	/home/ftp/mirrors/mirrors.coreix.net/elrepo-archive-archive/kernel
+	/home/ftp/mirrors/http/mirrors.coreix.net/elrepo-archive-archive/kernel
 
     # echo /home/ftp/mirrors/http/dev.centos.org
 }


### PR DESCRIPTION
…net/elrepo-archive-archive/kernel" which resulted in coreix.net kernels not being built.