### PR TITLE
Add SUSE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
+( cd portworx-mirror-server && ./install.sh ) &&
 ( cd pwx_test_kernel_pkgs && ./install.sh ) &&
-( cd pwx_test_kernels_in_mirror && ./install.sh ) &&
-( cd portworx-mirror-server && ./install.sh )
+( cd pwx_test_kernels_in_mirror && ./install.sh )

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -40,20 +40,22 @@ install_ftpd_ubuntu:
 	    ( cd / && xargs -- tar --create --dereference ) | \
 	    ( cd ~ftp && tar xp )
 
-install_httpd_ubuntu:
+add_user_pwxmirror:
+	adduser --system pwxmirror
+	chsh --shell /bin/bash pwxmirror
+
+install_httpd_ubuntu: add_user_pwxmirror
 	apt-get install --quiet --yes apache2
 	-rm -f /var/www/html/mirrors
 	-mkdir -p /var/www/html/mirrors
 	chown -R pwxmirror /var/www/html/mirrors
 	mv /var/www/html/index.html /var/www/html/index.html.orig 2> /dev/null || true
 
-install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_ubuntu
+install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_ubuntu add_user_pwxmirror
 	mkdir -p /var/log/portworx-mirror-server
-	adduser --system pwxmirror
-	chsh --shell /bin/bash pwxmirror
 	chown -R pwxmirror /home/pwxmirror /var/log/portworx-mirror-server
 	( . ${scriptsdir}/pwx-mirror-config.sh && \
-	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/opensuse $$mirrordir/misc/ubuntu && for subdir in centos debian opensuse ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )
+	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/suse $$mirrordir/misc/ubuntu && for subdir in centos debian suse ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )
 #	crontab -u pwxmirror ${scriptsdir}/crontab.txt
 #	^^^^^ Do not install the crontab for now, as the current  plan
 #	      is for the cron script to be run by Jensen.
@@ -84,7 +86,8 @@ install_pxdev_ubuntu: install_docker_ubuntu
 
 install_pxdev: install_pxdev_ubuntu
 
-install: install_docker install_mirror install_pxdev
+# install: install_docker install_mirror install_pxdev
+install: install_mirror
 
 clean:
 	-rm -f *~ \#* crontab.txt

--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -55,7 +55,7 @@ install_mirror_ubuntu: install_mirror_scripts install_httpd_ubuntu install_ftpd_
 	mkdir -p /var/log/portworx-mirror-server
 	chown -R pwxmirror /home/pwxmirror /var/log/portworx-mirror-server
 	( . ${scriptsdir}/pwx-mirror-config.sh && \
-	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/suse $$mirrordir/misc/ubuntu && for subdir in centos debian suse ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )
+	  mkdir -p $$mirrordir/misc/centos $$mirrordir/misc/debian $$mirrordir/misc/opensuse $$mirrordir/misc/ubuntu && for subdir in centos debian opensuse ubuntu ; do dir=$$mirrordir/misc/$$subdir ; file=$$dir/README.txt ; if [ ! -e "$$file" ] ; then echo "This directory is for unmirrored kernel header packages and support files related to $$subdir." > $$file ; fi ; done && chown -R pwxmirror $$mirrordir )
 #	crontab -u pwxmirror ${scriptsdir}/crontab.txt
 #	^^^^^ Do not install the crontab for now, as the current  plan
 #	      is for the cron script to be run by Jensen.

--- a/portworx-mirror-server/README.txt
+++ b/portworx-mirror-server/README.txt
@@ -2,3 +2,9 @@ To install the Portworx mirror server on a pristine Ubuntu 16.04 instance,
 do the following in this directory:
 
 sudo ./install.sh
+
+
+Also note that the script
+portworx-mirror-server/unused/extract-suse-kernels-from-dvd-files.sh
+can be used for extracting excerpts from SLES trial disc images (from
+.iso files) that can be put in ~ftp/mirrors/dvd/sue.

--- a/portworx-mirror-server/mirror-kernels.opensuse.sh
+++ b/portworx-mirror-server/mirror-kernels.opensuse.sh
@@ -32,7 +32,7 @@ mirror_download_opensuse_org() {
     #	xargs
     #
     # wget will not load the .rpm files from
-    # http://download.opensuse.org/distribution/openSUSE-current/repo/oss/suse/x86_64 unless "--level" is explicitly set to a big number because "the default
+    # http://download.opensuse.org/distribution/openSUSE-current/repo/oss/opensuse/x86_64 unless "--level" is explicitly set to a big number because "the default
     # maximum depth is 5" according to the wget manual page.
 
     # First update all index.html files, then look for new .rpm files without

--- a/portworx-mirror-server/unused/extract-suse-kernels-from-dvd-files.sh
+++ b/portworx-mirror-server/unused/extract-suse-kernels-from-dvd-files.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Usage:
-# extract-suse-kernels-from-dvd-files.sh file1.iso file2.iso ....
+# extract-opensuse-kernels-from-dvd-files.sh file1.iso file2.iso ....
 
 for iso in "$@" ; do
     no_dir=${iso##*/}

--- a/portworx-mirror-server/unused/extract-suse-kernels-from-dvd-files.sh
+++ b/portworx-mirror-server/unused/extract-suse-kernels-from-dvd-files.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Usage:
+# extract-suse-kernels-from-dvd-files.sh file1.iso file2.iso ....
+
+for iso in "$@" ; do
+    no_dir=${iso##*/}
+    no_iso=${no_dir%.iso}
+    mount -o ro,loop -t iso9660 "$iso" /mnt
+    unpack_dir="/home/adam/portworx/dvd_excerpts/$no_iso"
+    mkdir -p "$unpack_dir"
+    (cd /mnt && (
+	    find . \( -name 'kernel-*devel*.rpm' -o \
+		 -name 'kernel-*source*.rpm' \) -print0 |
+		xargs --null -- tar -cp ) ) |
+	( cd "$unpack_dir" && tar xp )
+    umount /mnt
+done

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -110,6 +110,7 @@ stop_container_lxc() {
 }
 
 in_container_lxc() {
+    echo "AJR in_container_lxc $*" >&2
     lxc-attach --name "$container_name" --clear-env \
         --set-var \
             PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -7,8 +7,19 @@ container_name=
 
 await_default_route() {
     local count=100
+    local route_command
+    
+    if in_container_lxc ip netconf > /dev/null 2>&1 ; then
+	route_command="ip route"
+    else
+	route_command="route"
+    fi
+
     while [[ $count -gt 0 ]] ; do
-	if in_container_lxc ip route | egrep --quiet '^default via ' ; then
+	# if in_container_lxc ip route | egrep --quiet '^default via ' ; then
+	#    return 0
+	# fi
+	if in_container_lxc $route_command | egrep --quiet '^default[ 	]' ; then
 	    return 0
 	fi
 	sleep 0.1

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -110,7 +110,6 @@ stop_container_lxc() {
 }
 
 in_container_lxc() {
-    echo "AJR in_container_lxc $*" >&2
     lxc-attach --name "$container_name" --clear-env \
         --set-var \
             PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -8,7 +8,6 @@ pkg_files_to_names_centos()       { pkg_files_to_names_rpm        "$@" ; }
 pkg_files_to_dependencies_centos() { pkg_files_to_dependencies_rpm "$@" ; }
 install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
 install_pkgs_dir_centos()         { install_pkgs_dir_rpm          "$@" ; }
-install_pkgs_centos()             { install_pkgs_rpm              "$@" ; }
 uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -36,8 +36,8 @@ install_pkgs_dir_opensuse()
 {
     # FIXME.  What about dependencies?
     # in_container sh -c "rpm --install $1/*"
-    echo "AJR install_pkgs_dir_opensuse: packages: " >&2
-    in_container sh -c "cd $1 && ls -l" >&2
+    # echo "AJR install_pkgs_dir_opensuse: packages: " >&2
+    # in_container sh -c "cd $1 && ls -l" >&2
     in_container sh -c "zypper --non-interactive --gpg-auto-import-keys install $1/*"
 }
 

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -3,12 +3,12 @@
 
 # For now, just default everything to the common Opensuse drivers.
 
-pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
-pkg_files_to_dependencies_opensuse() { pkg_files_to_dependencies_rpm "$@" ; }
-dist_clean_up_container_opensuse()  { dist_clean_up_container_rpm   "$@" ; }
-dist_start_container_opensuse()     { dist_start_container_rpm      "$@"; }
+pkg_files_to_names_suse()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_suse() { pkg_files_to_dependencies_rpm "$@" ; }
+dist_clean_up_container_suse()  { dist_clean_up_container_rpm   "$@" ; }
+dist_start_container_suse()     { dist_start_container_rpm      "$@"; }
 
-dist_init_container_opensuse()
+dist_init_container_suse()
 {
     dist_init_container_rpm       "$@"
     in_container sh -c "echo pkg_gpgcheck = off >> /etc/zypp/zypp.conf"
@@ -16,48 +16,48 @@ dist_init_container_opensuse()
     in_container sh -c "echo gpgcheck = off >> /etc/zypp/zypp.conf"
 }
 
-pkg_files_to_kernel_dirs_opensuse()
+pkg_files_to_kernel_dirs_suse()
 {
     rpm --query --list --package "$@" |
 	awk '{print $NF}' |
-	egrep '^/usr/src/linux-[0-9][-0-9.]*-obj/[^/]+/[^/]+' |
-	sed 's:^\.\?\(/usr/src/linux-[0-9.][^/]*/[^/]*/[^/]*\)/.*$:\1:' |
+	egrep '^/usr/src/linux-[0-9][-0-9a-z.]*-obj/[^/]+/[^/]+' |
+	sed 's:^\.\?\(/usr/src/linux-[^/]*/[^/]*/[^/]*\)/.*$:\1:' |
 	uniq |
 	sort -u
 	# | egrep -v '^/usr/src/linux-[0-9.]+-[0-9.]+-obj$'
 }
 
-install_pkgs_opensuse()
+install_pkgs_suse()
 {
     in_container zypper --non-interactive --gpg-auto-import-keys install "$@"
 }
 
-install_pkgs_dir_opensuse()
+install_pkgs_dir_suse()
 {
     # FIXME.  What about dependencies?
     # in_container sh -c "rpm --install $1/*"
-    echo "AJR install_pkgs_dir_opensuse: packages: " >&2
+    echo "AJR install_pkgs_dir_suse: packages: " >&2
     in_container sh -c "cd $1 && ls -l" >&2
     in_container sh -c "zypper --non-interactive --gpg-auto-import-keys install $1/*"
 }
 
-uninstall_pkgs_opensuse()
+uninstall_pkgs_suse()
 {
     in_container zypper --non-interactive --gpg-auto-import-keys remove "$@"
 }
 
-pkgs_update_opensuse()
+pkgs_update_suse()
 {
     in_container zypper --non-interactive --gpg-auto-import-keys update
 }
 
-#dist_init_container_opensuse()
+#dist_init_container_suse()
 #{
 #    # in_container zypper --non-interactive --gpg-auto-import-keys install yum
 #    dist_init_container_rpm "$@"
 #}
 
-get_dist_releases_opensuse()
+get_dist_releases_suse()
 {
     echo "42.2 13.2"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -5,9 +5,16 @@
 
 pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
 pkg_files_to_dependencies_opensuse() { pkg_files_to_dependencies_rpm "$@" ; }
-dist_init_container_opensuse()      { dist_init_container_rpm       "$@" ; }
 dist_clean_up_container_opensuse()  { dist_clean_up_container_rpm   "$@" ; }
 dist_start_container_opensuse()     { dist_start_container_rpm      "$@"; }
+
+dist_init_container_opensuse()
+{
+    dist_init_container_rpm       "$@"
+    in_container sh -c "echo pkg_gpgcheck = off >> /etc/zypp/zypp.conf"
+    in_container sh -c "echo repo_gpgcheck = off >> /etc/zypp/zypp.conf"
+    in_container sh -c "echo gpgcheck = off >> /etc/zypp/zypp.conf"
+}
 
 pkg_files_to_kernel_dirs_opensuse()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -1,0 +1,46 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common Opensuse drivers.
+
+pkg_files_to_kernel_dirs_opensuse() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
+pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_opensuse() { pkg_files_to_dependencies_rpm "$@" ; }
+dist_init_container_opensuse()      { dist_init_container_rpm       "$@" ; }
+dist_clean_up_container_opensuse()  { dist_clean_up_container_rpm   "$@" ; }
+dist_start_container_opensuse()     { dist_start_container_rpm      "$@"; }
+
+install_pkgs_opensuse()
+{
+    in_container zypper --non-interactive --gpg-auto-import-keys install "$@"
+}
+
+install_pkgs_dir_opensuse()
+{
+    # FIXME.  What about dependencies?
+    # in_container sh -c "rpm --install $1/*"
+    echo "AJR install_pkgs_dir_opensuse: packages: " >&2
+    in_container sh -c "cd $1 && ls -l" >&2
+    in_container sh -c "zypper --non-interactive --gpg-auto-import-keys install $1/*"
+}
+
+uninstall_pkgs_opensuse()
+{
+    in_container zypper --non-interactive --gpg-auto-import-keys remove "$@"
+}
+
+pkgs_update_opensuse()
+{
+    in_container zypper --non-interactive --gpg-auto-import-keys update
+}
+
+#dist_init_container_opensuse()
+#{
+#    # in_container zypper --non-interactive --gpg-auto-import-keys install yum
+#    dist_init_container_rpm "$@"
+#}
+
+get_dist_releases_opensuse()
+{
+    echo "42.2 13.2"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -3,12 +3,22 @@
 
 # For now, just default everything to the common Opensuse drivers.
 
-pkg_files_to_kernel_dirs_opensuse() { pkg_files_to_kernel_dirs_rpm  "$@" ; }
 pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
 pkg_files_to_dependencies_opensuse() { pkg_files_to_dependencies_rpm "$@" ; }
 dist_init_container_opensuse()      { dist_init_container_rpm       "$@" ; }
 dist_clean_up_container_opensuse()  { dist_clean_up_container_rpm   "$@" ; }
 dist_start_container_opensuse()     { dist_start_container_rpm      "$@"; }
+
+pkg_files_to_kernel_dirs_opensuse()
+{
+    rpm --query --list --package "$@" |
+	awk '{print $NF}' |
+	egrep '^/usr/src/linux-[0-9][-0-9.]*-obj/[^/]+/[^/]+' |
+	sed 's:^\.\?\(/usr/src/linux-[0-9.][^/]*/[^/]*/[^/]*\)/.*$:\1:' |
+	uniq |
+	sort -u
+	# | egrep -v '^/usr/src/linux-[0-9.]+-[0-9.]+-obj$'
+}
 
 install_pkgs_opensuse()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -1,14 +1,14 @@
 # This is not a standalone program.  It is a library to be sourced by a shell
 # script.
 
-# For now, just default everything to the common Opensuse drivers.
+# For now, just default everything to the common Openopensuse drivers.
 
-pkg_files_to_names_suse()       { pkg_files_to_names_rpm        "$@" ; }
-pkg_files_to_dependencies_suse() { pkg_files_to_dependencies_rpm "$@" ; }
-dist_clean_up_container_suse()  { dist_clean_up_container_rpm   "$@" ; }
-dist_start_container_suse()     { dist_start_container_rpm      "$@"; }
+pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_opensuse() { pkg_files_to_dependencies_rpm "$@" ; }
+dist_clean_up_container_opensuse()  { dist_clean_up_container_rpm   "$@" ; }
+dist_start_container_opensuse()     { dist_start_container_rpm      "$@"; }
 
-dist_init_container_suse()
+dist_init_container_opensuse()
 {
     dist_init_container_rpm       "$@"
     in_container sh -c "echo pkg_gpgcheck = off >> /etc/zypp/zypp.conf"
@@ -16,7 +16,7 @@ dist_init_container_suse()
     in_container sh -c "echo gpgcheck = off >> /etc/zypp/zypp.conf"
 }
 
-pkg_files_to_kernel_dirs_suse()
+pkg_files_to_kernel_dirs_opensuse()
 {
     rpm --query --list --package "$@" |
 	awk '{print $NF}' |
@@ -27,37 +27,37 @@ pkg_files_to_kernel_dirs_suse()
 	# | egrep -v '^/usr/src/linux-[0-9.]+-[0-9.]+-obj$'
 }
 
-install_pkgs_suse()
+install_pkgs_opensuse()
 {
     in_container zypper --non-interactive --gpg-auto-import-keys install "$@"
 }
 
-install_pkgs_dir_suse()
+install_pkgs_dir_opensuse()
 {
     # FIXME.  What about dependencies?
     # in_container sh -c "rpm --install $1/*"
-    echo "AJR install_pkgs_dir_suse: packages: " >&2
+    echo "AJR install_pkgs_dir_opensuse: packages: " >&2
     in_container sh -c "cd $1 && ls -l" >&2
     in_container sh -c "zypper --non-interactive --gpg-auto-import-keys install $1/*"
 }
 
-uninstall_pkgs_suse()
+uninstall_pkgs_opensuse()
 {
     in_container zypper --non-interactive --gpg-auto-import-keys remove "$@"
 }
 
-pkgs_update_suse()
+pkgs_update_opensuse()
 {
     in_container zypper --non-interactive --gpg-auto-import-keys update
 }
 
-#dist_init_container_suse()
+#dist_init_container_opensuse()
 #{
 #    # in_container zypper --non-interactive --gpg-auto-import-keys install yum
 #    dist_init_container_rpm "$@"
 #}
 
-get_dist_releases_suse()
+get_dist_releases_opensuse()
 {
     echo "42.2 13.2"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -14,7 +14,6 @@ dist_init_container_rpm() {
 	fi
 	iteration=$((iteration + 1))
     done
-    echo "AJR dist_init_container_rpm: packages loaded after iteration=$iteration" >&2
     
     uninstall_pkgs kernel-devel   # FIXME? Is this command necessary?
 }

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -4,7 +4,7 @@
 dist_init_container_rpm() {
     # dist_init_container_rpm calls {,un}install_pkgs rather than
     # {,un}install_pkgs_rpm so that OpenSUSE can use this function
-    # while still having {,un}install_pkgs_suse.
+    # while still having {,un}install_pkgs_opensuse.
     local iteration
     iteration=1
     while [[ $iteration -lt 10 ]] ; do

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -2,8 +2,16 @@
 # script.
 
 dist_init_container_rpm() {
-    install_pkgs_rpm autoconf automake gcc gcc-c++ git make tar
-
+    local iteration
+    iteration=1
+    while [[ $iteration -lt 10 ]] ; do
+        install_pkgs_rpm autoconf automake gcc gcc-c++ git make tar
+	if in_container autoreconf --help > /dev/null 2>&1 ; then
+	    break
+	fi
+	iteration=$((iteration + 1))
+    done
+    
     uninstall_pkgs_rpm kernel-devel   # FIXME? Is this command necessary?
 }
 

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -4,7 +4,7 @@
 dist_init_container_rpm() {
     # dist_init_container_rpm calls {,un}install_pkgs rather than
     # {,un}install_pkgs_rpm so that OpenSUSE can use this function
-    # while still having {,un}install_pkgs_opensuse.
+    # while still having {,un}install_pkgs_suse.
     local iteration
     iteration=1
     while [[ $iteration -lt 10 ]] ; do

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -2,26 +2,31 @@
 # script.
 
 dist_init_container_rpm() {
+    # dist_init_container_rpm calls {,un}install_pkgs rather than
+    # {,un}install_pkgs_rpm so that OpenSUSE can use this function
+    # while still having {,un}install_pkgs_opensuse.
     local iteration
     iteration=1
     while [[ $iteration -lt 10 ]] ; do
-        install_pkgs_rpm autoconf automake gcc gcc-c++ git make tar
+        install_pkgs autoconf automake gcc gcc-c++ git make tar
 	if in_container autoreconf --help > /dev/null 2>&1 ; then
 	    break
 	fi
 	iteration=$((iteration + 1))
     done
+    echo "AJR dist_init_container_rpm: packages loaded after iteration=$iteration" >&2
     
-    uninstall_pkgs_rpm kernel-devel   # FIXME? Is this command necessary?
+    uninstall_pkgs kernel-devel   # FIXME? Is this command necessary?
 }
 
 pkg_files_to_kernel_dirs_rpm() {
     rpm --query --list --package "$@" |
 	awk '{print $NF}' |
-	egrep '^\.?/usr/src/kernels/' |
-	sed 's|^\.\?\(/usr/src/kernels/[^/]*\)/.*$|\1|' |
+	egrep '^(\.?/usr/src/kernels/|/usr/src/linux-[0-9])' |
+	sed 's:^\.\?\(/usr/src/\(kernels/\|linux-[0-9]\)[^/]*\)/.*$:\1:' |
 	uniq |
 	sort -u
+	# | egrep -v '^/usr/src/linux-[0-9.]+-[0-9.]+-obj$'
 }
 
 pkg_files_to_names_rpm () {

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -8,7 +8,7 @@
 . $scriptsdir/distro_driver.ubuntu.sh
 . $scriptsdir/distro_driver.centos.sh
 . $scriptsdir/distro_driver.fedora.sh
-. $scriptsdir/distro_driver.suse.sh
+. $scriptsdir/distro_driver.opensuse.sh
 
 # These commands are selected based on the format of the kernel header
 # package files being used (.rpm or .deb)

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -8,7 +8,7 @@
 . $scriptsdir/distro_driver.ubuntu.sh
 . $scriptsdir/distro_driver.centos.sh
 . $scriptsdir/distro_driver.fedora.sh
-. $scriptsdir/distro_driver.opensuse.sh
+. $scriptsdir/distro_driver.suse.sh
 
 # These commands are selected based on the format of the kernel header
 # package files being used (.rpm or .deb)

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -8,6 +8,7 @@
 . $scriptsdir/distro_driver.ubuntu.sh
 . $scriptsdir/distro_driver.centos.sh
 . $scriptsdir/distro_driver.fedora.sh
+. $scriptsdir/distro_driver.opensuse.sh
 
 # These commands are selected based on the format of the kernel header
 # package files being used (.rpm or .deb)

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -174,6 +174,10 @@ test_kernel_pkgs_func() {
 	# to become longer than a pipe buffer, although this would probably
 	# never happen.
 
+	if [[ -z "$headers_dir" ]] ; then
+	    echo "AJR test_kernel_pkgs_func: null \$headers_dir, \$* = $*." >&2
+	fi
+
 	in_container sh -c \
 		     "cd ${container_tmpdir}/pxfuse_dir && \
                   autoreconf && \

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -175,7 +175,8 @@ test_kernel_pkgs_func() {
 	# never happen.
 
 	if [[ -z "$headers_dir" ]] ; then
-	    echo "AJR test_kernel_pkgs_func: null \$headers_dir, \$* = $*." >&2
+	    echo "FATAL: test_kernel_pkgs_func: null \$headers_dir, \$* = $*." >&2
+	    return 1
 	fi
 
 	in_container sh -c \

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -59,7 +59,7 @@ chmod a+x \
 #
 # install_crontab
 
-for dist in centos debian fedora opensuse ubuntu ; do
+for dist in centos debian fedora suse ubuntu ; do
     mkdir -p "${downloads_dir}/${dist}"
 done
 

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -59,7 +59,7 @@ chmod a+x \
 #
 # install_crontab
 
-for dist in centos debian fedora ubuntu ; do
+for dist in centos debian fedora opensuse ubuntu ; do
     mkdir -p "${downloads_dir}/${dist}"
 done
 

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -59,7 +59,7 @@ chmod a+x \
 #
 # install_crontab
 
-for dist in centos debian fedora suse ubuntu ; do
+for dist in centos debian fedora opensuse ubuntu ; do
     mkdir -p "${downloads_dir}/${dist}"
 done
 

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -1,0 +1,82 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common Opensuse drivers.
+
+pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
+
+get_default_mirror_dirs_opensuse()
+{
+    echo \
+	/home/ftp/mirrors/http/download.opensuse.org/distribution \
+	/home/ftp/mirrors/http/download.opensuse.org/update
+
+    # echo /home/ftp/mirrors/http/dev.opensuse.org
+}
+
+walk_nonarch_file_opensuse()
+{
+    local nonarch_full_path="$1"
+    local noarch_dir=${nonarch_full_path%/*}
+    local all_archs_dir=${noarch_dir%/*}
+
+    local filename=${nonarch_full_path##*/}
+    local noarch_filename=${filename%.noarch.rpm}
+    local version=${noarch_filename#kernel-devel-}
+    local return_status=0
+    local arch_full_path rpm_arch
+    local adjective src_rpm src_dep src_rpm
+
+    shift
+
+    if [[ ".$arch" = ".amd64" ]] ; then
+	rpm_arch=x86_64
+    else
+	rpm_arch="$arch"
+    fi
+
+    find "$all_archs_dir" -name "kernel-*-devel-${version}.${rpm_arch}.rpm" \
+	 -print0 |
+	while read -r -d $'\0' arch_full_path ; do
+	    src_dep=$(rpm -qpR "$arch_full_path" 2> /dev/null |
+			     egrep 'kernel-source.* = ' |
+			     sed 's/ *= */-/' )
+	    if [[ -n "$src_dep" ]] ; then
+		src_rpm=$(find "$noarch_dir" -name "${src_dep}-*.noarch.rpm" |
+				  sort | tail -1)
+	    else
+		src_rpm=""
+	    fi
+	    
+	    if ! "$@" "$arch_full_path" "$nonarch_full_path" $src_rpm ; then
+		return_status=$?
+	    fi
+	done
+    return $return_status
+}
+
+read0_walk_nonarch_files_opensuse()
+{
+    local return_status=0
+    local nonarch_file
+
+    while read -r -d $'\0' nonarch_file ; do
+	if ! walk_nonarch_file_opensuse "$nonarch_file" "$@" ; then
+	    return_status=$?
+	fi
+    done
+    return $return_status
+}
+
+
+walk_mirror_opensuse()
+{
+    local mirror_tree="$1"
+    local kernel_regexp=".*/kernel-devel-${above_3_9_regexp}[0-9.]*-[0-9.]*\.noarch\.rpm"
+
+    shift
+
+    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f \
+	 -print0 |
+	read0_walk_nonarch_files_opensuse "$@"
+}

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -14,13 +14,13 @@ get_default_mirror_dirs_opensuse()
 }
 
 list_noarch_dirs_opensuse() {
-    local noarch_dir="$1"
+    local all_archs_dir="$1"
     local dvds_dir="/home/ftp/mirrors/dvd/opensuse"
 
-    echo "$noarch_dir"
+    echo "$all_archs_dir/noarch"
 
     # Skip directories that are not named to indicate a CD or DVD image.
-    case "$noarch_dir" in
+    case "$all_archs_dir" in
 	${dvds_dir}/SLE-*-DVD[0-9] ) ;;
 	${dvds_dir}/SLE-*-DVD[0-9]/* ) ;;
 	${dvds_dir}/SLE-*-CD[0-9] ) ;;
@@ -28,7 +28,7 @@ list_noarch_dirs_opensuse() {
 	* ) return 0 ;;
     esac
 
-    within_discs_dir=${noarch_dir#${dvds_dir}/}
+    within_discs_dir=${all_archs_dir#${dvds_dir}/}
     disc=${within_discs_dir%%/*}
     disc_no_number=${disc%[0-9]}
     parent_disc_no_number=$(echo "$disc_no_number" |

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -1,23 +1,21 @@
 # This is not a standalone program.  It is a library to be sourced by a shell
 # script.
 
-# For now, just default everything to the common Opensuse drivers.
+pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
 
-pkg_files_to_names_suse()       { pkg_files_to_names_rpm        "$@" ; }
-
-get_default_mirror_dirs_suse()
+get_default_mirror_dirs_opensuse()
 {
     echo \
 	/home/ftp/mirrors/http/download.opensuse.org/distribution \
 	/home/ftp/mirrors/http/download.opensuse.org/update \
-	/home/ftp/mirrors/dvd/suse
+	/home/ftp/mirrors/dvd/opensuse
 
-	# echo /home/ftp/mirrors/http/dev.suse.org
+	# echo /home/ftp/mirrors/http/dev.opensuse.org
 }
 
-list_noarch_dirs_suse() {
+list_noarch_dirs_opensuse() {
     local noarch_dir="$1"
-    local dvds_dir="/home/ftp/mirrors/dvd/suse"
+    local dvds_dir="/home/ftp/mirrors/dvd/opensuse"
 
     echo "$noarch_dir"
 
@@ -38,7 +36,7 @@ list_noarch_dirs_suse() {
 
     (
 	cd "$dvds_dir" &&
-	    for dir in $dvds_dir/${disc_no_number}[0-9]/suse/noarch $dvds_dir/${parent_disc_no_number}[0-9]/suse/noarch ; do
+	    for dir in $dvds_dir/${disc_no_number}[0-9]/opensuse/noarch $dvds_dir/${parent_disc_no_number}[0-9]/opensuse/noarch ; do
 		if [[ -e "$dir" ]] ; then
 		    echo "$dir"
 		fi
@@ -46,14 +44,14 @@ list_noarch_dirs_suse() {
     )
 }
 
-find_noarch_file_suse()
+find_noarch_file_opensuse()
 {
     local all_archs_dir="$1"
     local name_hyphen_version="$2"
     local file="${name_hyphen_vesion}.noarch.rpm"
     local dir dir_and_file
 
-    for dir in $(list_noarch_dirs_suse "$all_archs_dir") ; do
+    for dir in $(list_noarch_dirs_opensuse "$all_archs_dir") ; do
 	dir_and_file="$dir/$file"
 	if [ ! -e "$dir_and_file" ] ; then
 	    dir_and_file=$(find "$dir" -maxdepth 1 -name "${name_hyphen_version}.[0-9]*.noarch.rpm" -print | sort -r | head -1)
@@ -65,7 +63,7 @@ find_noarch_file_suse()
     done
 }
 
-maybe_add_deps_rpms_suse() {
+maybe_add_deps_rpms_opensuse() {
     local full_path="$1"
     local all_archs_dir=${full_path%/*/*}
     local dep deps
@@ -75,11 +73,11 @@ maybe_add_deps_rpms_suse() {
 		     sed 's/ *= */-/' |
 		     sort -u)
     for dep in $deps ; do
-	find_noarch_file_suse "$all_archs_dir" "${dep}"
+	find_noarch_file_opensuse "$all_archs_dir" "${dep}"
     done
 }
 
-walk_arch_file_suse()
+walk_arch_file_opensuse()
 {
     local rpm_arch="$1"
     local arch_full_path="$2"
@@ -91,15 +89,15 @@ walk_arch_file_suse()
     local return_status=0
     local noarch_full_path dir
 
-    noarch_full_path=$( find_noarch_file_suse "$all_archs_dir" \
+    noarch_full_path=$( find_noarch_file_opensuse "$all_archs_dir" \
 			 "kernel-devel-${version}" )
     shift 2
 
     "$@" "$arch_full_path" "$noarch_full_path" \
-	 $(maybe_add_deps_rpms_suse "$arch_full_path")
+	 $(maybe_add_deps_rpms_opensuse "$arch_full_path")
 }
 
-read0_walk_arch_files_suse()
+read0_walk_arch_files_opensuse()
 {
     local rpm_arch="$1"
     local return_status=0
@@ -108,7 +106,7 @@ read0_walk_arch_files_suse()
     shift
 
     while read -r -d $'\0' arch_file ; do
-	if ! walk_arch_file_suse "$rpm_arch" "$arch_file" "$@" ; then
+	if ! walk_arch_file_opensuse "$rpm_arch" "$arch_file" "$@" ; then
 	    return_status=$?
 	fi
     done
@@ -116,7 +114,7 @@ read0_walk_arch_files_suse()
 }
 
 
-walk_mirror_suse()
+walk_mirror_opensuse()
 {
     local mirror_tree="$1"
     local kernel_regexp rpm_arch
@@ -133,5 +131,5 @@ walk_mirror_suse()
 
    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f \
 	 -print0 |
-	read0_walk_arch_files_suse "$rpm_arch" "$@"
+	read0_walk_arch_files_opensuse "$rpm_arch" "$@"
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -9,7 +9,8 @@ get_default_mirror_dirs_opensuse()
 {
     echo \
 	/home/ftp/mirrors/http/download.opensuse.org/distribution \
-	/home/ftp/mirrors/http/download.opensuse.org/update
+	/home/ftp/mirrors/http/download.opensuse.org/update \
+	/home/ftp/mirrors/dvd/suse
 
     # echo /home/ftp/mirrors/http/dev.opensuse.org
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -48,7 +48,7 @@ find_noarch_file_opensuse()
 {
     local all_archs_dir="$1"
     local name_hyphen_version="$2"
-    local file="${name_hyphen_vesion}.noarch.rpm"
+    local file="${name_hyphen_version}.noarch.rpm"
     local dir dir_and_file
 
     for dir in $(list_noarch_dirs_opensuse "$all_archs_dir") ; do

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -3,30 +3,123 @@
 
 # For now, just default everything to the common Opensuse drivers.
 
-pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_names_suse()       { pkg_files_to_names_rpm        "$@" ; }
 
-get_default_mirror_dirs_opensuse()
+get_default_mirror_dirs_suse()
 {
     echo \
 	/home/ftp/mirrors/http/download.opensuse.org/distribution \
 	/home/ftp/mirrors/http/download.opensuse.org/update \
 	/home/ftp/mirrors/dvd/suse
 
-    # echo /home/ftp/mirrors/http/dev.opensuse.org
+	# echo /home/ftp/mirrors/http/dev.suse.org
 }
 
-walk_nonarch_file_opensuse()
-{
-    local nonarch_full_path="$1"
-    local noarch_dir=${nonarch_full_path%/*}
-    local all_archs_dir=${noarch_dir%/*}
+list_noarch_dirs_suse() {
+    local noarch_dir="$1"
+    local dvds_dir="/home/ftp/mirrors/dvd/suse"
 
-    local filename=${nonarch_full_path##*/}
-    local noarch_filename=${filename%.noarch.rpm}
-    local version=${noarch_filename#kernel-devel-}
+    echo "$noarch_dir"
+
+    # Skip directories that are not named to indicate a CD or DVD image.
+    case "$noarch_dir" in
+	${dvds_dir}/SLE-*-DVD[0-9] ) ;;
+	${dvds_dir}/SLE-*-DVD[0-9]/* ) ;;
+	${dvds_dir}/SLE-*-CD[0-9] ) ;;
+	${dvds_dir}/SLE-*-CD[0-9]/* ) ;;
+	* ) return 0 ;;
+    esac
+
+    within_discs_dir=${noarch_dir#${dvds_dir}/}
+    disc=${within_discs_dir%%/*}
+    disc_no_number=${disc%[0-9]}
+    parent_disc_no_number=$(echo "$disc_no_number" |
+	sed 's/^SLE\(S\?-[0-9]\+\(-SP[0-9]\+\)\?\-\)[A-Za-z]\+-/SLE\1Server-/')
+
+    (
+	cd "$dvds_dir" &&
+	    for dir in $dvds_dir/${disc_no_number}[0-9]/suse/noarch $dvds_dir/${parent_disc_no_number}[0-9]/suse/noarch ; do
+		if [[ -e "$dir" ]] ; then
+		    echo "$dir"
+		fi
+	    done
+    )
+}
+
+find_noarch_file_suse()
+{
+    local all_archs_dir="$1"
+    local name_hyphen_version="$2"
+    local file="${name_hyphen_vesion}.noarch.rpm"
+    local dir dir_and_file
+
+    for dir in $(list_noarch_dirs_suse "$all_archs_dir") ; do
+	dir_and_file="$dir/$file"
+	if [ ! -e "$dir_and_file" ] ; then
+	    dir_and_file=$(find "$dir" -maxdepth 1 -name "${name_hyphen_version}.[0-9]*.noarch.rpm" -print | sort -r | head -1)
+	fi
+	if [ -e "$dir_and_file" ] ; then
+	    echo "$dir_and_file"
+	    break
+	fi
+    done
+}
+
+maybe_add_deps_rpms_suse() {
+    local full_path="$1"
+    local all_archs_dir=${full_path%/*/*}
+    local dep deps
+
+    deps=$(rpm -qpR "$full_path" 2> /dev/null |
+		     egrep ' = ' |
+		     sed 's/ *= */-/' |
+		     sort -u)
+    for dep in $deps ; do
+	find_noarch_file_suse "$all_archs_dir" "${dep}"
+    done
+}
+
+walk_arch_file_suse()
+{
+    local rpm_arch="$1"
+    local arch_full_path="$2"
+    local all_archs_dir=${arch_full_path%/*/*}
+
+    local filename=${arch_full_path##*/}
+    local arch_filename=${filename%.${rpm_arch}.rpm}
+    local version=${arch_filename#kernel-*-devel-}
     local return_status=0
-    local arch_full_path rpm_arch
-    local adjective src_rpm src_dep src_rpm
+    local noarch_full_path dir
+
+    noarch_full_path=$( find_noarch_file_suse "$all_archs_dir" \
+			 "kernel-devel-${version}" )
+    shift 2
+
+    "$@" "$arch_full_path" "$noarch_full_path" \
+	 $(maybe_add_deps_rpms_suse "$arch_full_path")
+}
+
+read0_walk_arch_files_suse()
+{
+    local rpm_arch="$1"
+    local return_status=0
+    local arch_file rpm_arch
+
+    shift
+
+    while read -r -d $'\0' arch_file ; do
+	if ! walk_arch_file_suse "$rpm_arch" "$arch_file" "$@" ; then
+	    return_status=$?
+	fi
+    done
+    return $return_status
+}
+
+
+walk_mirror_suse()
+{
+    local mirror_tree="$1"
+    local kernel_regexp rpm_arch
 
     shift
 
@@ -36,48 +129,9 @@ walk_nonarch_file_opensuse()
 	rpm_arch="$arch"
     fi
 
-    find "$all_archs_dir" -name "kernel-*-devel-${version}.${rpm_arch}.rpm" \
+    kernel_regexp=".*/kernel-.*-devel-${above_3_9_regexp}[0-9.]*-[0-9.]*\.${rpm_arch}\.rpm"
+
+   find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f \
 	 -print0 |
-	while read -r -d $'\0' arch_full_path ; do
-	    src_dep=$(rpm -qpR "$arch_full_path" 2> /dev/null |
-			     egrep 'kernel-source.* = ' |
-			     sed 's/ *= */-/' )
-	    if [[ -n "$src_dep" ]] ; then
-		src_rpm=$(find "$noarch_dir" -name "${src_dep}-*.noarch.rpm" |
-				  sort | tail -1)
-	    else
-		src_rpm=""
-	    fi
-	    
-	    if ! "$@" "$arch_full_path" "$nonarch_full_path" $src_rpm ; then
-		return_status=$?
-	    fi
-	done
-    return $return_status
-}
-
-read0_walk_nonarch_files_opensuse()
-{
-    local return_status=0
-    local nonarch_file
-
-    while read -r -d $'\0' nonarch_file ; do
-	if ! walk_nonarch_file_opensuse "$nonarch_file" "$@" ; then
-	    return_status=$?
-	fi
-    done
-    return $return_status
-}
-
-
-walk_mirror_opensuse()
-{
-    local mirror_tree="$1"
-    local kernel_regexp=".*/kernel-devel-${above_3_9_regexp}[0-9.]*-[0-9.]*\.noarch\.rpm"
-
-    shift
-
-    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f \
-	 -print0 |
-	read0_walk_nonarch_files_opensuse "$@"
+	read0_walk_arch_files_suse "$rpm_arch" "$@"
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.opensuse.sh
@@ -8,7 +8,7 @@ get_default_mirror_dirs_opensuse()
     echo \
 	/home/ftp/mirrors/http/download.opensuse.org/distribution \
 	/home/ftp/mirrors/http/download.opensuse.org/update \
-	/home/ftp/mirrors/dvd/opensuse
+	/home/ftp/mirrors/dvd/suse
 
 	# echo /home/ftp/mirrors/http/dev.opensuse.org
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -8,7 +8,7 @@
 . $scriptsdir/mirror_walk_driver.ubuntu.sh
 . $scriptsdir/mirror_walk_driver.centos.sh
 . $scriptsdir/mirror_walk_driver.fedora.sh
-. $scriptsdir/mirror_walk_driver.suse.sh
+. $scriptsdir/mirror_walk_driver.opensuse.sh
 
 # Used for selecting kernels version 3.10 or later.  Used by some drivers.
 above_3_9_regexp='(3\.[1-9][0-9]+|[4-9][0-9]*|[1-9][0-9]+)(\.[.0-9]+[0-9])?'

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -8,6 +8,7 @@
 . $scriptsdir/mirror_walk_driver.ubuntu.sh
 . $scriptsdir/mirror_walk_driver.centos.sh
 . $scriptsdir/mirror_walk_driver.fedora.sh
+. $scriptsdir/mirror_walk_driver.opensuse.sh
 
 # Used for selecting kernels version 3.10 or later.  Used by some drivers.
 above_3_9_regexp='(3\.[1-9][0-9]+|[4-9][0-9]*|[1-9][0-9]+)(\.[.0-9]+[0-9])?'

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -8,7 +8,7 @@
 . $scriptsdir/mirror_walk_driver.ubuntu.sh
 . $scriptsdir/mirror_walk_driver.centos.sh
 . $scriptsdir/mirror_walk_driver.fedora.sh
-. $scriptsdir/mirror_walk_driver.opensuse.sh
+. $scriptsdir/mirror_walk_driver.suse.sh
 
 # Used for selecting kernels version 3.10 or later.  Used by some drivers.
 above_3_9_regexp='(3\.[1-9][0-9]+|[4-9][0-9]*|[1-9][0-9]+)(\.[.0-9]+[0-9])?'

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -16,7 +16,7 @@ stop_lxc_test_containers() {
 
 main() {
     local result=0
-    for dist in centos debian fedora ubuntu ; do
+    for dist in centos debian fedora opensuse ubuntu ; do
 	if ! pwx_test_kernels_in_mirror --distribution="$dist" \
 	     --command-args="--leave-containers-running --containers=lxc" ; then
 	    result=$?

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -16,7 +16,7 @@ stop_lxc_test_containers() {
 
 main() {
     local result=0
-    for dist in centos debian fedora suse ubuntu ; do
+    for dist in centos debian fedora opensuse ubuntu ; do
 	if ! pwx_test_kernels_in_mirror --distribution="$dist" \
 	     --command-args="--leave-containers-running --containers=lxc" ; then
 	    result=$?

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -16,7 +16,7 @@ stop_lxc_test_containers() {
 
 main() {
     local result=0
-    for dist in centos debian fedora opensuse ubuntu ; do
+    for dist in centos debian fedora suse ubuntu ; do
 	if ! pwx_test_kernels_in_mirror --distribution="$dist" \
 	     --command-args="--leave-containers-running --containers=lxc" ; then
 	    result=$?

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
@@ -15,8 +15,7 @@ Options:
         --help
         --logdir=logdir                [default: based on distribution]
         --mirror-top=mirror_top_dir
-        --pfxuse=pxfuse_src_dir        [default: download tempoary
-
+        --pfxuse=pxfuse_src_dir        [default: download temporary]
 EOF
 }
 


### PR DESCRIPTION
Add http://download.opensuse.org/distribution, http://download.opensuse.org/update and ~ftp/mirrrors/dvd/suse (the latter for excerpted DVD images), along with support to OpenSUSE builds.

The script portworx-mirror-server/unused/extract-suse-kernels-from-dvd-files.sh can be used for extracting excerpts from SLES trial disc images (from .iso files) that can be put in ~ftp/mirrors/dvd/sue.