### PR TITLE
Add build results for opensuse to build summary, plus a trivial error message fix that I happened to commit just before this.

### DIFF
--- a/pwx_test_kernel_pkgs/container_driver.sh
+++ b/pwx_test_kernel_pkgs/container_driver.sh
@@ -24,7 +24,7 @@ start_container()
     if [[ -z "$release" ]] ; then
 	release=$(set $(get_dist_releases) ; echo $1)
 	if [[ -z "$release" ]] ; then
-	    echo "start_container_lxc: Unable to determine default release for distribution \"${distro}\"." >&2
+	    echo "start_container: Unable to determine default release for distribution \"${distro}\"." >&2
 	    echo "Failing." >&2
 	    return 1
 	fi

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -32,7 +32,7 @@ if [[ $# -eq 0 ]] ; then
 fi
 
 if [[ $# -eq 1 ]] && [[ ".$1" = ".--recursive" ]] ; then
-    for dist in centos debian fedora ubuntu ; do
+    for dist in centos debian fedora ubuntu opensuse ; do
 	cmd=$(realpath "$0")
 	pwx_test_kernels_in_mirror --distribution="$dist" --command="$cmd"
 	symlinks -c "$for_installer_dir"


### PR DESCRIPTION
1. Add build results for opensuse to build summary.
2. Trivially fix an error message (correct the name of the function that generated the error message).  I just happened to commit this change before the opensuse change.
