### PR TITLE
Add CoreOS

### DIFF
--- a/portworx-mirror-server/mirror-kernels.coreos.sh
+++ b/portworx-mirror-server/mirror-kernels.coreos.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# ^^ requires bash because save_error() calls bash_stack_trace,
+# which uses bash-specific command "caller".
+
+scriptsdir=$PWD
+. ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
+mkdir -p ${mirrordir}
+cd ${mirrordir} || exit $?
+
+mirrordir=/home/ftp/mirrors
+
+
+#arch=i386
+arch=amd64
+
+TIMESTAMPING=--timestamping
+#TIMESTAMPING=--no-clobber
+
+mirror_coreos() {
+    local release="$1"
+    local prefix="https://${release}.release.core-os.net"
+    
+    wget ${TIMESTAMPING} --quiet --protocol-directories \
+	 --force-directories --accept=index.html --recursive \
+	 "${prefix}/"
+
+    wget ${TIMESTAMPING} --quiet --protocol-directories \
+	 --force-directories --accept=index.html \
+	 "${prefix}/${arch}-usr/current/coreos_production_iso_image.iso"
+}
+
+mirror_coreos stable
+# mirror_coreos alpha
+# mirror_coreos beta

--- a/portworx-mirror-server/mirror-kernels.coreos.sh
+++ b/portworx-mirror-server/mirror-kernels.coreos.sh
@@ -25,9 +25,10 @@ mirror_coreos() {
 	 --force-directories --accept=index.html --recursive \
 	 "${prefix}/"
 
-    wget ${TIMESTAMPING} --quiet --protocol-directories \
-	 --force-directories --accept=index.html \
-	 "${prefix}/${arch}-usr/current/coreos_production_iso_image.iso"
+    wget ${TIMESTAMPING} --quiet --protocol-directories --recursive \
+	 --force-directories \
+	 --accept-regex='.*/(index.html|.*\.iso)?$' \
+	 "${prefix}/${arch}-usr/"
 }
 
 mirror_coreos stable

--- a/pwx_test_kernel_pkgs/container_driver.docker.sh
+++ b/pwx_test_kernel_pkgs/container_driver.docker.sh
@@ -6,9 +6,11 @@ docker_pid=
 start_container_docker() {
     local container_name id
     local release=""
+    local distribution=""
 
     while [[ $# -gt 0 ]] ; do
 	case "$1" in
+	    --distribution=* ) distribution="${1#--distribution=}" ;;
 	    --release=* ) release="${1#--release=}" ;;
 	    --* ) echo "start_container_lxc: Unrecognized argument \"$1\"." >&2 ;;
 	    -- ) shift ; break ;;
@@ -17,14 +19,17 @@ start_container_docker() {
 	shift
     done
 
+    if [[ -z "$distribution" ]] ; then
+	echo "start_container_lxc: --distribution=disto missing." >&2
+	return 1
+    fi
+
     if [[ -z "$release" ]] ; then
 	echo "start_container_lxc: --release=dist_release missing." >&2
 	return 1
     fi
 
-    # FIXME.  Support selection of distribution release.
-    # container_name="pwx_test_${distribution}_${release}"
-    container_name="pwx_test_${distribution}"
+    container_name="pwx_test_${distribution}_${release}"
 
     systemctl start docker
     id=$(docker ps --quiet=true --all=true --filter name="${container_name}")

--- a/pwx_test_kernel_pkgs/container_driver.lxc.sh
+++ b/pwx_test_kernel_pkgs/container_driver.lxc.sh
@@ -47,9 +47,11 @@ is_container_running() {
 start_container_lxc() {
     local must_initialize
     local release=""
+    local distribution=""
 
     while [[ $# -gt 0 ]] ; do
 	case "$1" in
+	    --distribution=* ) distribution="${1#--distribution=}" ;;
 	    --release=* ) release="${1#--release=}" ;;
 	    --* ) echo "start_container_lxc: Unrecognized argument \"$1\"." >&2 ;;
 	    -- ) shift ; break ;;
@@ -58,12 +60,17 @@ start_container_lxc() {
 	shift
     done
 
+    if [[ -z "$distribution" ]] ; then
+	echo "start_container_lxc: --distribution=disto missing." >&2
+	return 1
+    fi
+
     if [[ -z "$release" ]] ; then
 	echo "start_container_lxc: --release=dist_release missing." >&2
 	return 1
     fi
 
-    container_name="pwx_test_${distro}_${release}"
+    container_name="pwx_test_${distribution}_${release}"
 
     lxc-ls > /dev/null 2>&1 || true
     # ^^^ Removes incompletely initialized containters
@@ -73,7 +80,7 @@ start_container_lxc() {
     else
 	must_initialize=true
 	lxc-create --name "${container_name}" --template download -- \
-		     --dist "$distro" --arch "$arch" --release "$release"
+		     --dist "$distribution" --arch "$arch" --release "$release"
     fi
 
     if ! is_container_running "${container_name}" ; then

--- a/pwx_test_kernel_pkgs/container_driver.sh
+++ b/pwx_test_kernel_pkgs/container_driver.sh
@@ -4,15 +4,18 @@ container_system=docker	# force this default for now.
 . $scriptsdir/container_driver.docker.sh
 . $scriptsdir/container_driver.lxc.sh
 
+start_container() { "start_container_$distro" "$@" ; }
 stop_container() { "stop_container_$container_system" "$@" ; }
 in_container() { "in_container_$container_system" "$@" ; }
 
-start_container()
+start_container_generic()
 {
     local release=""
+    local distribution="$distro"
 
     while [[ $# -gt 0 ]] ; do
 	case "$1" in
+	    --distribution=* ) distribution="${1#--distribution=}" ;;
 	    --release=* ) release="${1#--release=}" ;;
 	    -- ) shift ; break ;;
 	    --* ) echo "start_container: Unrecognized argument \"$1\"." >&2 ;;
@@ -22,7 +25,7 @@ start_container()
     done
 
     if [[ -z "$release" ]] ; then
-	release=$(set $(get_dist_releases) ; echo $1)
+	release=$(set $(get_dist_releases_$distribution) ; echo $1)
 	if [[ -z "$release" ]] ; then
 	    echo "start_container: Unable to determine default release for distribution \"${distro}\"." >&2
 	    echo "Failing." >&2
@@ -30,7 +33,7 @@ start_container()
 	fi
     fi
 
-    "start_container_$container_system" --release="$release" "$@"
+    "start_container_$container_system" --distribution="$distribution" --release="$release" "$@"
 }
 
 

--- a/pwx_test_kernel_pkgs/distro_driver.centos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.centos.sh
@@ -12,7 +12,8 @@ uninstall_pkgs_centos()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_centos()              { pkgs_update_rpm               "$@" ; }
 dist_init_container_centos()      { dist_init_container_rpm       "$@" ; }
 dist_clean_up_container_centos()  { dist_clean_up_container_rpm   "$@" ; }
-dist_start_container_centos()     { dist_start_container_rpm      "$@"; }
+dist_start_container_centos()     { dist_start_container_rpm      "$@" ; }
+start_container_centos()          { start_container_generic       "$@" ; }
 
 get_dist_releases_centos()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.coreos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.coreos.sh
@@ -1,0 +1,69 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common RPM drivers.
+
+coreos_remote_tmp_dir=/tmp/coreos_remote_tmp_dir
+
+pkg_files_to_names_coreos()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_coreos() { pkg_files_to_dependencies_rpm "$@" ; }
+install_pkgs_coreos()             { install_pkgs_rpm              "$@" ; }
+install_pkgs_dir_coreos()         { install_pkgs_dir_rpm          "$@" ; }
+uninstall_pkgs_coreos()           { uninstall_pkgs_rpm            "$@" ; }
+pkgs_update_coreos()              { pkgs_update_rpm               "$@" ; }
+dist_start_container_coreos()     { dist_start_container_rpm      "$@" ; }
+
+start_container_coreos()
+{
+    # lxc-create does not provide a CoreOS template, so build
+    # under CentOS for now.
+
+    start_container_generic --distribution=centos "$@"
+}
+
+dist_init_container_coreos() { dist_init_container_rpm "$@" ; }
+
+install_pkgs_coreos()             { install_pkgs_rpm              "$@" ; }
+install_pkgs_dir_coreos()         { install_pkgs_dir_rpm          "$@" ; }
+uninstall_pkgs_coreos()           { uninstall_pkgs_rpm            "$@" ; }
+
+# Rely on dist_clean_up_container_coreos to remove the CoreOS
+# .iso files that were installed by install_pkgs_dir_coreos.  So,
+# pkg_files_to_names_coreos and pkg_files_to_dependencies_coreoss
+# do not output the names of any packages to remove or install.
+pkg_files_to_names_coreos()        { true ; }
+pkg_files_to_dependencies_coreos() { true ; }
+
+install_pkgs_dir_coreos()
+{
+    install_pkgs genisoimage squashfs-tools
+    in_container sh -c "
+	set -x ;
+	rm -rf $coreos_remote_tmp_dir/squashfs-root ;
+	mkdir -p $coreos_remote_tmp_dir &&
+	for iso_file in $1/* ; do
+		isoinfo -J -R -x /coreos/cpio.gz -i \$iso_file |
+			gunzip |
+			( cd $coreos_remote_tmp_dir && cpio --extract usr.squashfs ) &&
+		( cd $coreos_remote_tmp_dir && unsquashfs usr.squashfs lib lib64/modules ) ;
+	done"
+}
+
+get_dist_releases_coreos()
+{
+    # For now, build from the latest Centos release only.  CoreOS
+    # does not include gcc by default.
+    set -- $(get_dist_releases_centos "$@")
+    echo "$1"
+}
+
+pkg_files_to_kernel_dirs_coreos()
+{
+    in_container sh -c "echo $coreos_remote_tmp_dir/squashfs-root/lib/modules/[0-9]*/build"
+}
+
+dist_clean_up_container_coreos()
+{
+    in_container rm -rf "$coreos_remote_tmp_dir"
+    dist_clean_up_container_rpm   "$@"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.debian.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.debian.sh
@@ -15,6 +15,7 @@ uninstall_pkgs_debian()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_debian()              { pkgs_update_deb               "$@" ; }
 dist_clean_up_container_debian()  { dist_clean_up_container_deb   "$@" ; }
 dist_start_container_debian()     { dist_start_container_deb      "$@"; }
+start_container_debian()          { start_container_generic "$@" ; }
 
 get_dist_releases_debian()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.fedora.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.fedora.sh
@@ -12,7 +12,8 @@ uninstall_pkgs_fedora()           { uninstall_pkgs_rpm            "$@" ; }
 pkgs_update_fedora()              { pkgs_update_rpm               "$@" ; }
 dist_init_container_fedora()      { dist_init_container_rpm       "$@" ; }
 dist_clean_up_container_fedora()  { dist_clean_up_container_rpm   "$@" ; }
-dist_start_container_fedora()     { dist_start_container_rpm      "$@"; }
+dist_start_container_fedora()     { dist_start_container_rpm      "$@" ; }
+start_container_fedora()          { start_container_generic       "$@" ; }
 
 get_dist_releases_fedora()
 {

--- a/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.opensuse.sh
@@ -5,6 +5,7 @@
 
 pkg_files_to_names_opensuse()       { pkg_files_to_names_rpm        "$@" ; }
 pkg_files_to_dependencies_opensuse() { pkg_files_to_dependencies_rpm "$@" ; }
+start_container_opensuse()          { start_container_generic "$@" ; }
 dist_clean_up_container_opensuse()  { dist_clean_up_container_rpm   "$@" ; }
 dist_start_container_opensuse()     { dist_start_container_rpm      "$@"; }
 

--- a/pwx_test_kernel_pkgs/distro_driver.rpm.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.rpm.sh
@@ -60,9 +60,27 @@ install_pkgs_dir_rpm_notyet()
     done
 }
 
-install_pkgs_rpm()     { in_container yum --assumeyes --quiet install "$@" ; }
+install_pkgs_rpm()
+{
+    # CoreOS ends up calling this function with no parameters, which
+    # is why this function checks for that.
+
+    if [[ $# -gt 0 ]] ; then
+	in_container yum --assumeyes --quiet install "$@"
+    fi
+}
+
 #uninstall_pkgs_rpm()   { in_container rpm --erase "$@" ; }
-uninstall_pkgs_rpm()   { in_container yum --assumeyes remove "$@" ; }
+uninstall_pkgs_rpm()
+{
+    # CoreOS ends up calling this function with no parameters, which
+    # is why this function checks for that.
+
+    if [[ $# -gt 0 ]] ; then
+	in_container yum --assumeyes remove "$@"
+    fi
+}
+
 pkgs_update_rpm()      { in_container yum --assumeyes --quiet update ; }
 dist_clean_up_container_rpm() { true; }	# No-op for now.
 dist_start_container_rpm() { true; }

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -7,6 +7,7 @@
 . $scriptsdir/distro_driver.debian.sh
 . $scriptsdir/distro_driver.ubuntu.sh
 . $scriptsdir/distro_driver.centos.sh
+. $scriptsdir/distro_driver.coreos.sh
 . $scriptsdir/distro_driver.fedora.sh
 . $scriptsdir/distro_driver.opensuse.sh
 

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -13,6 +13,7 @@ uninstall_pkgs_ubuntu()           { uninstall_pkgs_deb            "$@" ; }
 pkgs_update_ubuntu()              { pkgs_update_deb               "$@" ; }
 dist_clean_up_container_ubuntu()  { dist_clean_up_container_deb   "$@" ; }
 dist_start_container_ubuntu()     { dist_start_container_deb      "$@"; }
+start_container_ubuntu()          { start_container_generic "$@" ; }
 
 get_dist_releases_ubuntu()
 {

--- a/pwx_test_kernel_pkgs/pwx_test_containers_stop.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_containers_stop.sh
@@ -34,7 +34,7 @@ done
 
 main()
 {
-    local releaes releases
+    local release releases
 
     if [[ -n "$distro_releases" ]] ; then
 	releases=$(echo "$distro_releases" | sed 's/,/ /g')

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -59,7 +59,7 @@ chmod a+x \
 #
 # install_crontab
 
-for dist in centos debian fedora opensuse ubuntu ; do
+for dist in centos coreos debian fedora opensuse ubuntu ; do
     mkdir -p "${downloads_dir}/${dist}"
 done
 

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.coreos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.coreos.sh
@@ -1,0 +1,34 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+pkg_files_to_names_coreos()       { true ; }
+
+get_default_mirror_dirs_coreos()
+{
+    local release protocol dir
+    for release in stable alpha beta ; do
+	for protocol in http https ; do
+	    dir="/home/ftp/mirrors/${protocol}/${release}.release.core-os.net/amd64-usr"
+	    if [[ -e "$dir" ]] ; then
+		echo "$dir"
+	    fi
+	done
+    done
+}
+
+walk_mirror_coreos() {
+    local mirror_tree="$1"
+    local return_status=0
+    local file
+
+    shift 1
+
+    find "$mirror_tree" -name '*.iso' -type f -print0 |
+	while read -r -d $'\0' file ; do
+            if ! "$@" "$file" ; then
+		return_status=$?
+	    fi
+	done
+
+    return $return_status
+}

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -7,6 +7,7 @@
 . $scriptsdir/mirror_walk_driver.debian.sh
 . $scriptsdir/mirror_walk_driver.ubuntu.sh
 . $scriptsdir/mirror_walk_driver.centos.sh
+. $scriptsdir/mirror_walk_driver.coreos.sh
 . $scriptsdir/mirror_walk_driver.fedora.sh
 . $scriptsdir/mirror_walk_driver.opensuse.sh
 

--- a/pwx_test_kernels_in_mirror/programming-interface.txt
+++ b/pwx_test_kernels_in_mirror/programming-interface.txt
@@ -58,8 +58,9 @@ DESCRIPTION OF INTERNAL FUNCTIONS
 
 	The distribution interface uses the $distribution shell global
 	variable to select the distribution type.  Currently, "ubuntu",
-	"debian" and "centos" are supported.  Every shell function func
-	listed below is just a wrapper that invokes func_$distribution.
+	"debian", "centos", "coreos" and "opensuse" are supported.
+	Every shell function, func, listed below is just a wrapper
+	that invokes func_$distribution.
 
 	pkg_files_to_names	- Given a list of package files output
 				  the names of the packages that those

--- a/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
+++ b/pwx_test_kernels_in_mirror/pwx_export_results_for_installer.sh
@@ -13,7 +13,8 @@ Usage:
 
 The "--recursive" usage is probably normally the only one you want to invoke.
 It calls pwx_export_results_for_install.sh via pwx_test_kernels_in_mirror for
-a set of known distributions (currently, CentOS, Debian, Fedora, and Ubuntu).
+a set of known distributions (currently, CentOS, CoreOS, Debian, Fedora,
+SUSE and Ubuntu).
 
 pxw_export_results_for_install.sh installs directories in
 ${for_installer_dir} based
@@ -32,7 +33,7 @@ if [[ $# -eq 0 ]] ; then
 fi
 
 if [[ $# -eq 1 ]] && [[ ".$1" = ".--recursive" ]] ; then
-    for dist in centos debian fedora ubuntu opensuse ; do
+    for dist in centos coreos debian fedora ubuntu opensuse ; do
 	cmd=$(realpath "$0")
 	pwx_test_kernels_in_mirror --distribution="$dist" --command="$cmd"
 	symlinks -c "$for_installer_dir"

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -16,7 +16,7 @@ stop_lxc_test_containers() {
 
 main() {
     local result=0
-    for dist in centos debian fedora opensuse ubuntu ; do
+    for dist in centos coreos debian fedora opensuse ubuntu ; do
 	if ! pwx_test_kernels_in_mirror --distribution="$dist" \
 	     --command-args="--leave-containers-running --containers=lxc" ; then
 	    result=$?


### PR DESCRIPTION
These changes have only been tested lightly, but I provide them so you have the option of trying them out now on a testing VM if you want.

Mirror and attempt to build CoreOS beta and stable releases, but not alpha releases just yet, due to concerns about storage space.

Stable and beta have ~85 images each of architecture amd64-usr, but alpha has ~245.  The images are about 200 megabytes each.  So, mirroring 170 of them  but  portworx-mirror-server/mirror-kernels.coreos.sh should use about 34GB, but mirroring alpha releases too would bring that total up to about 81GB.  I recommend we first try mirroring production and beta, take a look at how much storage space we have remaining on the virtual machines, and then determine if it will be necessary to resize (and perhaps recreate) the virtual machines with more space or if it is OK just to push a change to enable mirroring of the alpha releases (amd64 architecture, just like stable and beta).