### PR TITLE
CoreOS: Also mirror coreos_developer_container.bin.bz2*; mirror beta.release.core-os.net

### DIFF
--- a/portworx-mirror-server/mirror-kernels.coreos.sh
+++ b/portworx-mirror-server/mirror-kernels.coreos.sh
@@ -27,7 +27,7 @@ mirror_coreos() {
 
     wget ${TIMESTAMPING} --quiet --protocol-directories --recursive \
 	 --force-directories \
-	 --accept-regex='.*/(index.html|.*\.iso)?$' \
+	 --accept-regex='.*/(index.html|.*\.iso|coreos_developer_container\.bin.bz2.*)?$' \
 	 "${prefix}/${arch}-usr/"
 }
 

--- a/portworx-mirror-server/mirror-kernels.coreos.sh
+++ b/portworx-mirror-server/mirror-kernels.coreos.sh
@@ -33,4 +33,4 @@ mirror_coreos() {
 
 mirror_coreos stable
 # mirror_coreos alpha
-# mirror_coreos beta
+mirror_coreos beta


### PR DESCRIPTION
The important change here is to enable mirroring of the coreos_developer_container.bin.bz2* files, which are apparently necessary for building kernel modules for older versions of CoreOS.

There was also a commit previously queued that I was not aware of that enables mirroring of beta.release.core-os.net.  I thought my changes were already doing that, so I have left it in, but can add a commit to leave mirroring of the beta site disabled for now if that would be preferable.