### PR TITLE
Amazon Linux: Mirror kernel source RPM packages too, because some older kernels see…

### DIFF
--- a/portworx-mirror-server/mirror-kernels.amazon-linux.sh
+++ b/portworx-mirror-server/mirror-kernels.amazon-linux.sh
@@ -37,7 +37,7 @@ list_amazon_linux_urls() {
     # Amazon releases are four_digit_year.two_digit_month, where four_digit
     # year starts at 2011, and two_digit_month is 03 or 09.
     local confdir=/tmp/amazon-config.$$
-    local release_ver
+    local release_ver repos
     
     rm -rf "$confdir"
     cp -apr /home/pwxmirror/mirror-scripts/from_amazon_linux "$confdir"
@@ -46,6 +46,9 @@ list_amazon_linux_urls() {
       echo "installroot=${confdir}/"  # Prefix directory of etc/yum/vars.
       echo "reposdir=${confdir}/etc/yum.repos.d/" ) > "${confdir}/etc/yum.conf"
 
+    repos=$(cat "$confdir/etc/yum.repos.d"/*.repo |
+		   egrep '^\['  |
+		   sed 's/^\[/ --repo=/;s/\]$//')
     list_amazon_linux_versions |
 	while read release_ver ; do
 	    # FIXME.  This seems to look for the latest release anyhow.
@@ -54,9 +57,14 @@ list_amazon_linux_urls() {
 	    rm -rf "${confdir}/download"
 	    mkdir -p "${confdir}/download"
 	    reposync --download_path="${confdir}/download" --urls --source \
-		     --config="$confdir/etc/yum.conf" --quiet 2> /dev/null
+		     --config="$confdir/etc/yum.conf" $repos --quiet \
+		     2> /dev/null
 	done |
-	egrep 'kernel-devel.*\.rpm'
+	egrep 'kernel-devel.*\.rpm|/SRPMS/kernel-.*.src.rpm'
+
+    # The following filter should eliminate paths to the same filename:
+    # sort --reverse |
+    # awk -F/ '{paths[$1] = $0;} END {for (i in paths) {print paths[i];}}'
 
     rm -rf "$confdir"
 }
@@ -64,8 +72,8 @@ list_amazon_linux_urls() {
 mirror_amazon_linux() {
     list_amazon_linux_urls |
 	sort -u |
-	xargs --no-run-if-empty -- \
-	      wget --protocol-directories --force-directories --no-clobber
+	wget --protocol-directories --force-directories --no-clobber \
+	     --quiet --input-file=-
 
     save_error
 }

--- a/portworx-mirror-server/mirror-kernels.amazon-linux.sh
+++ b/portworx-mirror-server/mirror-kernels.amazon-linux.sh
@@ -10,6 +10,7 @@ scriptsdir=$PWD
 . ${scriptsdir}/pwx-mirror-util.sh
 cd ${mirrordir} || exit $?
 mkdir -p ${mirrordir}
+amzn_confdir_template=/home/pwxmirror/mirror-scripts/from_amazon_linux
 
 # TIMESTAMPING=--timestamping
 TIMESTAMPING='--no-clobber --no-use-server-timestamps'
@@ -18,7 +19,7 @@ QUIET=
 
 error_code=0
 
-list_amazon_linux_versions() {
+amzn_list_versions() {
     local endyear=$(date +%Y)
     local year
 
@@ -33,33 +34,48 @@ list_amazon_linux_versions() {
     done
 }
 
-list_amazon_linux_urls() {
+amzn_init_confdir() {
+    local confdir="$1"
+
+    rm -rf "$confdir" "/var/tmp/yum-$(whoami)-"*
+    cp -apr "${amzn_confdir_template}" "$confdir"
+    mkdir -p "${confdir}/var/log" "${confdir}/var/cache/yum"
+    sed "s|=/|=${confdir}/|" \
+            < ${amzn_confdir_template}/etc/yum.conf |
+    ( egrep -v '^(reposdir|installroot|releasever)='
+      echo "installroot=${confdir}/"  # Prefix directory of etc/yum/vars.
+      echo "reposdir=${confdir}/etc/yum.repos.d/" ) \
+	> "${confdir}/etc/yum.conf"
+}
+
+amzn_list_urls() {
     # Amazon releases are four_digit_year.two_digit_month, where four_digit
     # year starts at 2011, and two_digit_month is 03 or 09.
     local confdir=/tmp/amazon-config.$$
     local release_ver repos
-    
-    rm -rf "$confdir"
-    cp -apr /home/pwxmirror/mirror-scripts/from_amazon_linux "$confdir"
-    ( egrep -v '^(reposdir|installroot|releasever)=' \
-	    < /home/pwxmirror/mirror-scripts/from_amazon_linux/etc/yum.conf
-      echo "installroot=${confdir}/"  # Prefix directory of etc/yum/vars.
-      echo "reposdir=${confdir}/etc/yum.repos.d/" ) > "${confdir}/etc/yum.conf"
 
-    repos=$(cat "$confdir/etc/yum.repos.d"/*.repo |
+    repos=$(cat "${amzn_confdir_template}/etc/yum.repos.d"/*.repo |
 		   egrep '^\['  |
-		   sed 's/^\[/ --repo=/;s/\]$//')
-    list_amazon_linux_versions |
-	while read release_ver ; do
-	    # FIXME.  This seems to look for the latest release anyhow.
-	    echo "$release_ver" > "$confdir/etc/yum/vars/releasever"
-	    echo "releasever=${release_ver}" >> "$confdir/etc/yum.conf"
-	    rm -rf "${confdir}/download"
-	    mkdir -p "${confdir}/download"
+		   sed 's/^\[/ --repo=/;s/\]$//' )
+
+    amzn_list_versions | while read release_ver ; do
+
+        amzn_init_confdir "${confdir}"
+
+	# FIXME.  This seems to look for the latest release anyhow.
+	echo -n "$release_ver" > "$confdir/etc/yum/vars/releasever"
+	echo "releasever=${release_ver}" >> "$confdir/etc/yum.conf"
+	rm -rf "${confdir}/download" "${confdir}/var/lib/yum"
+	mkdir -p "${confdir}/download"
+	# Apparently "--source" only works when repos are specified.  Also,
+	# reposync will abort if an unknown repo is specified.  So, run
+	# reposync separately on echo repo.
+	for repo in $repos ; do
 	    reposync --download_path="${confdir}/download" --urls --source \
-		     --config="$confdir/etc/yum.conf" $repos --quiet \
-		     2> /dev/null
-	done |
+		     --config="${confdir}/etc/yum.conf" $repo
+	done
+#	--quiet 2> /dev/null
+    done |
 	egrep 'kernel-devel.*\.rpm|/SRPMS/kernel-.*.src.rpm'
 
     # The following filter should eliminate paths to the same filename:
@@ -70,10 +86,10 @@ list_amazon_linux_urls() {
 }
 
 mirror_amazon_linux() {
-    list_amazon_linux_urls |
+    amzn_list_urls |
 	sort -u |
 	wget --protocol-directories --force-directories --no-clobber \
-	     --quiet --input-file=-
+	     --input-file=-
 
     save_error
 }


### PR DESCRIPTION
…m to be available only that way.  For example, right now (July, 2017), the 2017.03 release has kernel-devel and source RPM packages available, the 2016.09 release offers kernel source RPM packages and no kernel-devel packages anymore, even though they are list by "reposync --url", and all other releases no longer seem to offer either, even though they too show links for both kernel source RPM and kernel-devel packages.

By the way, mirroring of files from the previous release (2016.09) appears to be sporadic, which may be correlated to different IP's being returned from resolving packages.us-west-1.amazonaws.com.  It is possible that some servers have the files and some do not, but none seem to have the previous release's kernel-devel RPM packages, so mirroring the source packages appears to be necessary.

Update 2017-07-17: This pull request now includes numerous changes that have the result of showing numerous older kernel-devel packages for older release.  It appears that the kernel source RPM's are only available for 2016.09 and 2017.03 releases.  At least one of these older kernel-devel packages, and probably all of them, can be downloaded for mirrroring.  The most consequential changes appears to be the addition of doing "rm -rf /var/tmp/yum-$(whoami)-*" before switching versions.  Perhaps this is works around my misunderstanding of some reposync caching issue, or perhaps it is working around a real reposync or yum bug.  Anyhow merging this pull request should increase number of Amazon Linux kernel versions the system will attempt to build.