### PR TITLE
Move hosting of Amazon Linux builds from Fedora to Centos

### DIFF
--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -7,6 +7,8 @@ pkg_files_to_names_centos()       { pkg_files_to_names_rpm        "$@" ; }
 
 get_default_mirror_dirs_centos()
 {
+    local dir
+	
     echo \
 	/home/ftp/mirrors/http/elrepo.org/linux/kernel \
 	/home/ftp/mirrors/http/mirror.centos.org/centos \
@@ -14,6 +16,12 @@ get_default_mirror_dirs_centos()
 	/home/ftp/mirrors/http/mirrors.coreix.net/elrepo-archive-archive/kernel
 
     # echo /home/ftp/mirrors/http/dev.centos.org
+
+    for dir in /home/ftp/mirrors/http/packages.*.amazonaws.com/ ; do
+	if [ -e "$dir" ] ; then
+	    echo "$dir"
+	fi
+    done
 }
 
 walk_mirror_centos() {

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.centos.sh
@@ -31,7 +31,8 @@ walk_mirror_centos() {
     return_status=0
 
     kernel_regexp=".*/kernel-([a-z]+-)?devel-${above_3_9_regexp}[0-9.]*-.*${rpm_arch}.rpm"
-    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f -print0 |
+    find "$mirror_tree" -regextype egrep -regex "$kernel_regexp" -type f \
+	 -print0 |
 	while read -r -d $'\0' file ; do
             if ! "$@" "$file" ; then
 		return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.fedora.sh
@@ -7,14 +7,7 @@ pkg_files_to_names_fedora()       { pkg_files_to_names_rpm        "$@" ; }
 
 get_default_mirror_dirs_fedora()
 {
-    local dir
     echo /home/ftp/mirrors/http/ftp.linux.ncsu.edu/pub/fedora/linux/releases
-    for dir in /home/ftp/mirrors/http/packages.*.amazonaws.com/ ; do
-	if [ -e "$dir" ] ; then
-	    echo "$dir"
-	fi
-    done
-	
 }
 
 walk_mirror_fedora() {


### PR DESCRIPTION
Move build hosting of Amazon Linux from Fedora to Centos, to eliminate complaints about missing compiler-gcc5.h and compiler-gcc6.h files.  With this change, builds of px.ko with all currently mirrored Amazon Linux kernel-devel .rpm package files succeed.
