### PR TITLE
Add ChromiumOS

### DIFF
--- a/portworx-mirror-server/Makefile
+++ b/portworx-mirror-server/Makefile
@@ -83,6 +83,8 @@ install_docker: install_docker_ubuntu
 
 install_pxdev_ubuntu: install_docker_ubuntu
 	apt-get install -y git
+	apt-get install git-core gitk git-gui subversion curl # for ChromiumOS
+
 #	- ( cd ${scriptsdir} && git clone git://github.com/portworx/px-dev.git )
 # ^^^ For now, do not create /home/portworx/px-dev, but this may return
 # later, for testing in a a px-dev Docker container.

--- a/portworx-mirror-server/mirror-kernels.chromiumos.sh
+++ b/portworx-mirror-server/mirror-kernels.chromiumos.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# ^^ requires bash because save_error() calls bash_stack_trace,
+# which uses bash-specific command "caller".
+
+scriptsdir=$PWD
+. ${scriptsdir}/pwx-mirror-config.sh
+. ${scriptsdir}/pwx-mirror-util.sh
+mkdir -p ${mirrordir}
+cd ${mirrordir} || exit $?
+
+mirrordir=/home/ftp/mirrors
+
+
+#arch=i386
+arch=amd64
+
+TIMESTAMPING=--timestamping
+#TIMESTAMPING=--no-clobber
+
+is_string_in_colon_separated_list()
+{
+    local match="$1"
+    local list="$2"
+    local word
+
+    (
+        IFS=:
+        for word in $list ; do
+            if [[ ".$word" = ".$match" ]] ; then
+                exit 0
+            fi
+        done
+        exit 1
+    )
+}
+
+add_to_path()
+{
+    local dir
+    for dir in "$@" ; do
+        if ! is_string_in_colon_separated_list "$dir" "$PATH" ; then
+            PATH="${dir}:${PATH}"
+        fi
+    done
+}
+
+install_depot_tools() {
+    # From http://dev.chromium.org/developers/how-tos/install-depot-tools :
+    mkdir -p /home/ftp/mirrors/git/https/chromium.googlesource.com/chromium/tools
+    ( cd /home/ftp/mirrors/git/https/chromium.googlesource.com/chromium/tools &&
+      git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git )
+
+    add_to_path /home/ftp/mirrors/git/https/chromium.googlesource.com/chromium/tools/depot_tools
+    export PATH
+}
+
+mirror_chromiumos() {
+    # From http://www.chromium.org/chromium-os/quick-start-guide:
+
+    mkdir -p /home/ftp/mirrors/git/https/chromium.googlesource.com
+    cd /home/ftp/mirrors/git/https/chromium.googlesource.com || return $?
+
+    install_depot_tools
+
+    # cd ${SOURCE_REPO}
+    repo init -u https://chromium.googlesource.com/chromiumos/manifest.git
+
+    # Optional: Make any changes to .repo/local_manifests/local_manifest.xml before syncing
+    repo sync --force-sync
+}
+
+mirror_chromiumos_kernels() {
+    # From http://www.chromium.org/chromium-os/quick-start-guide:
+    local common="chromium.googlesource.com/chromiumos/third_party"
+    local parent="/home/ftp/mirrors/git/https/${common}"
+    local dir="${parent}/kernel"
+
+    mkdir -p "$parent"
+    cd "$parent" || return $?
+
+    git clone https://${common}/kernel ||
+	(cd kernel && git pull) ||
+	return $?
+}
+
+mirror_chromiumos_kernels

--- a/portworx-mirror-server/mirror-kernels.coreos.sh
+++ b/portworx-mirror-server/mirror-kernels.coreos.sh
@@ -32,5 +32,5 @@ mirror_coreos() {
 }
 
 mirror_coreos stable
-# mirror_coreos alpha
+mirror_coreos alpha
 mirror_coreos beta

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -37,10 +37,10 @@ pkg_files_to_dependencies_chromiumos() { true ; }
 install_pkgs_dir_chromiumos()
 {
     in_container sh -c "
-	set -x &&
-	rm -rf ${chromiumos_remote_tmp_dir}/kernel &&
-	mkdir -p ${chromiumos_remote_tmp_dir} &&
-	mv $1/* ${chromiumos_remote_tmp_dir}/kernel"
+        set -x &&
+        rm -rf ${chromiumos_remote_tmp_dir}/kernel &&
+        mkdir -p ${chromiumos_remote_tmp_dir} &&
+        mv $1/* ${chromiumos_remote_tmp_dir}/kernel"
 }
 
 get_dist_releases_chromiumos()
@@ -88,39 +88,39 @@ chromiumos_build() {
     if [[ -e "${commit_archive}" ]] &&
        ! tar -tJ < "${commit_archive}" > /dev/null ; then
 
-	rm -f "${commit_archive}"
+        rm -f "${commit_archive}"
     fi
 
     if [[ -e "${commit_archive}" ]] ; then
-	in_container sh -c \
+        in_container sh -c \
             "rm -rf ${container_tmpdir}/kernel &&
              mkdir -p ${container_tmpdir}/kernel &&
              cd ${container_tmpdir} &&
-	     tar -xpJ kernel" < "${commit_archive}" || return $?
-	headers_dir="${container_tmpdir}/kernel"
+             tar -xpJ kernel" < "${commit_archive}" || return $?
+        headers_dir="${container_tmpdir}/kernel"
     else
-	in_container sh -c \
+        in_container sh -c \
                "cd ${chromiumos_remote_tmp_dir}/kernel &&
-		git clean --force &&
-		git checkout ${branch} &&
-		./chromeos/scripts/prepareconfig chromiumos-x86_64 &&
-		make prepare &&
-		make scripts" || return $?
+                git clean --force &&
+                git checkout ${branch} &&
+                ./chromeos/scripts/prepareconfig chromiumos-x86_64 &&
+                make prepare &&
+                make scripts" || return $?
     fi
 
     default_build_func "${container_tmpdir}" "${headers_dir}" "${make_args}" ||
-	return $?
+        return $?
 
     if [[ -e "${commit_archive}" ]] ; then
-	return 0
+        return 0
     fi
 
     if ( in_container cat ${chromiumos_remote_tmp_dir}/kernel/.confg |
-	       grep '# CONFIG_MODVERSIONS is not set' ) ; then
+               grep '# CONFIG_MODVERSIONS is not set' ) ; then
 
-	# No need to build and save kernel symbol versions if kernel symbol
-	# versioning is disabled.
-	return 0
+        # No need to build and save kernel symbol versions if kernel symbol
+        # versioning is disabled.
+        return 0
     fi
 
     # Build the whole kernel (and possibly modules, depending on the
@@ -128,8 +128,8 @@ chromiumos_build() {
     # versioning information against which px.ko.
     in_container sh -c \
         "cd ${chromiumos_remote_tmp_dir}/kernel &&
-	 make vmlinux &&
-	 ${make_modules_command} &&
+         make vmlinux &&
+         ${make_modules_command} &&
          cd ${container_tmpdir}/pxfuse_dir &&
          make KERNELPATH=$headers_dir clean" || return $?
 

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -8,7 +8,6 @@ chromiumos_remote_tmp_dir=/tmp/chromiumos_remote_tmp_dir
 pkg_files_to_names_chromiumos()       { pkg_files_to_names_ubuntu     "$@" ; }
 pkg_files_to_dependencies_chromiumos() { pkg_files_to_dependencies_ubuntu "$@" ; }
 install_pkgs_chromiumos()             { install_pkgs_ubuntu           "$@" ; }
-install_pkgs_dir_chromiumos()         { install_pkgs_dir_ubuntu       "$@" ; }
 uninstall_pkgs_chromiumos()           { uninstall_pkgs_ubuntu         "$@" ; }
 pkgs_update_chromiumos()              { pkgs_update_ubuntu            "$@" ; }
 dist_start_container_chromiumos()     { dist_start_container_ubuntu   "$@" ; }
@@ -22,10 +21,6 @@ start_container_chromiumos()
 }
 
 dist_init_container_chromiumos() { dist_init_container_ubuntu "$@" ; }
-
-install_pkgs_chromiumos()             { install_pkgs_ubuntu           "$@" ; }
-install_pkgs_dir_chromiumos()         { install_pkgs_dir_ubuntu       "$@" ; }
-uninstall_pkgs_chromiumos()           { uninstall_pkgs_ubuntu         "$@" ; }
 
 # Rely on dist_clean_up_container_chromiumos to remove the Chromiumos
 # .iso files that were installed by install_pkgs_dir_chromiumos.  So,
@@ -61,17 +56,19 @@ dist_clean_up_container_chromiumos()
     dist_clean_up_container_ubuntu   "$@"
 }
 
-chromiumos_before_build() {
+chromiumos_prepare_build() {
     local container_tmpdir="$1"
     local branch="$3"
+
+    echo "AJR chromiumos_prepare_build $*" >&2
 
     install_pkgs curl
     # FIXME?  Is it necessory to "apt-get install" some other packages,
     # besides curl?
 
     in_container sh -c \
-	       "cd ${container_tmpdir} &&
-		git branch ${branch} &&
+               "cd ${chromiumos_remote_tmp_dir} &&
+		git checkout ${branch} &&
 		./chromeos/scripts/prepareconfig chromiumos-x86_64 &&
 		make prepare"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -60,15 +60,18 @@ chromiumos_prepare_build() {
     local container_tmpdir="$1"
     local branch="$3"
 
-    echo "AJR chromiumos_prepare_build $*" >&2
-
     install_pkgs curl
     # FIXME?  Is it necessory to "apt-get install" some other packages,
     # besides curl?
 
     in_container sh -c \
                "cd ${chromiumos_remote_tmp_dir} &&
+		git clean --force &&
 		git checkout ${branch} &&
 		./chromeos/scripts/prepareconfig chromiumos-x86_64 &&
-		make prepare"
+		make prepare &&
+		make scripts"
+    # 		make &&
+    #		make modules
+    # "make && make modules" is for kernel symbol versioning.
 }

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -76,9 +76,6 @@ chromiumos_build() {
     local make_modules_command="true"
     # local make_modules_command="make modules"
 
-    echo "AJR chromiumos_build called, commit_archive=$commit_archive." >&2
-    set -x # AJR 
-
     install_pkgs curl xz-utils
     # FIXME?  Is it necessory to "apt-get install" some other packages,
     # besides curl?

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -79,7 +79,7 @@ chromiumos_build() {
     echo "AJR chromiumos_build called, commit_archive=$commit_archive." >&2
     set -x # AJR 
 
-    install_pkgs curl
+    install_pkgs curl xz-utils
     # FIXME?  Is it necessory to "apt-get install" some other packages,
     # besides curl?
 

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -39,7 +39,7 @@ install_pkgs_dir_chromiumos()
     in_container sh -c "
 	set -x ;
 	rm -rf $chromiumos_remote_tmp_dir
-	mv $1/*/. $chromiumos_remote_tmp_dir"
+	mv $1/* $chromiumos_remote_tmp_dir"
 }
 
 get_dist_releases_chromiumos()
@@ -52,7 +52,7 @@ get_dist_releases_chromiumos()
 
 pkg_files_to_kernel_dirs_chromiumos()
 {
-    in_container sh -c "echo $chromiumos_remote_tmp_dir/squashfs-root/lib/modules/[0-9]*/build"
+    echo "${chromiumos_remote_tmp_dir}"
 }
 
 dist_clean_up_container_chromiumos()

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -115,7 +115,7 @@ chromiumos_build() {
         return 0
     fi
 
-    if ( in_container cat ${chromiumos_remote_tmp_dir}/kernel/.confg |
+    if ( in_container cat ${chromiumos_remote_tmp_dir}/kernel/.config |
                grep '# CONFIG_MODVERSIONS is not set' ) ; then
 
         # No need to build and save kernel symbol versions if kernel symbol

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -1,0 +1,84 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common RPM drivers.
+
+chromiumos_remote_tmp_dir=/tmp/chromiumos_remote_tmp_dir
+
+pkg_files_to_names_chromiumos()       { pkg_files_to_names_ubuntu     "$@" ; }
+pkg_files_to_dependencies_chromiumos() { pkg_files_to_dependencies_ubuntu "$@" ; }
+install_pkgs_chromiumos()             { install_pkgs_ubuntu           "$@" ; }
+install_pkgs_dir_chromiumos()         { install_pkgs_dir_ubuntu       "$@" ; }
+uninstall_pkgs_chromiumos()           { uninstall_pkgs_ubuntu         "$@" ; }
+pkgs_update_chromiumos()              { pkgs_update_ubuntu            "$@" ; }
+dist_start_container_chromiumos()     { dist_start_container_ubuntu   "$@" ; }
+
+start_container_chromiumos()
+{
+    # lxc-create does not provide a Chromiumos template, so build
+    # under Ubuntu for now.
+
+    start_container_generic --distribution=ubuntu "$@"
+}
+
+dist_init_container_chromiumos() { dist_init_container_ubuntu "$@" ; }
+
+install_pkgs_chromiumos()             { install_pkgs_ubuntu           "$@" ; }
+install_pkgs_dir_chromiumos()         { install_pkgs_dir_ubuntu       "$@" ; }
+uninstall_pkgs_chromiumos()           { uninstall_pkgs_ubuntu         "$@" ; }
+
+# Rely on dist_clean_up_container_chromiumos to remove the Chromiumos
+# .iso files that were installed by install_pkgs_dir_chromiumos.  So,
+# pkg_files_to_names_chromiumos and pkg_files_to_dependencies_chromiumoss
+# do not output the names of any packages to remove or install.
+pkg_files_to_names_chromiumos()        { true ; }
+pkg_files_to_dependencies_chromiumos() { true ; }
+
+install_pkgs_dir_chromiumos()
+{
+    install_pkgs genisoimage squashfs-tools
+    in_container sh -c "
+	set -x ;
+	rm -rf $chromiumos_remote_tmp_dir/squashfs-root ;
+	mkdir -p $chromiumos_remote_tmp_dir &&
+	for iso_file in $1/* ; do
+		isoinfo -J -R -x /chromiumos/cpio.gz -i \$iso_file |
+			gunzip |
+			( cd $chromiumos_remote_tmp_dir && cpio --extract usr.squashfs ) &&
+		( cd $chromiumos_remote_tmp_dir && unsquashfs usr.squashfs lib lib64/modules ) ;
+	done"
+}
+
+get_dist_releases_chromiumos()
+{
+    # For now, build from the latest Ubuntu release only.  Chromiumos
+    # does not include gcc by default.
+    set -- $(get_dist_releases_ubuntu "$@")
+    echo "$1"
+}
+
+pkg_files_to_kernel_dirs_chromiumos()
+{
+    in_container sh -c "echo $chromiumos_remote_tmp_dir/squashfs-root/lib/modules/[0-9]*/build"
+}
+
+dist_clean_up_container_chromiumos()
+{
+    in_container rm -rf "$chromiumos_remote_tmp_dir"
+    dist_clean_up_container_ubuntu   "$@"
+}
+
+chromiumos_before_build() {
+    local container_tmpdir="$1"
+    local branch="$3"
+
+    install_pkgs curl
+    # FIXME?  Is it necessory to "apt-get install" some other packages,
+    # besides curl?
+
+    in_container sh -c \
+	       "cd ${container_tmpdir} &&
+		git branch ${branch} &&
+		./chromeos/scripts/prepareconfig chromiumos-x86_64 &&
+		make prepare"
+}

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -71,8 +71,8 @@ chromiumos_build() {
     # this optimization, set the variable make_modules_command to "true" (a
     # no-op) instead of "make modules":
     #
-    # local make_modules_command="true"
-    local make_modules_command="make modules"
+    local make_modules_command="true"
+    # local make_modules_command="make modules"
 
     install_pkgs curl
     # FIXME?  Is it necessory to "apt-get install" some other packages,

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -115,6 +115,14 @@ chromiumos_build() {
 	return 0
     fi
 
+    if ( in_container cat ${chromiumos_remote_tmp_dir}/kernel/.confg |
+	       grep '# CONFIG_MODVERSIONS is not set' ) ; then
+
+	# No need to build and save kernel symbol versions if kernel symbol
+	# versioning is disabled.
+	return 0
+    fi
+
     # Build the whole kernel (and possibly modules, depending on the
     # value of ${make_modules_command}), just to have kernel symbol
     # versioning information against which px.ko.

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -3,6 +3,11 @@
 
 # For now, just default everything to the common RPM drivers.
 
+# Change the following line to ...= false to inhibit saving .tar.xz files
+# of successful versioned kernel builds.
+chromiumos_save_kernel_builds=true
+# chromiumos_save_kernel_builds=false
+
 chromiumos_remote_tmp_dir=/tmp/chromiumos_remote_tmp_dir
 
 pkg_files_to_names_chromiumos()       { pkg_files_to_names_ubuntu     "$@" ; }
@@ -122,12 +127,14 @@ chromiumos_build() {
 
     mkdir -p "${commit_archive%/*}" || return $?
 
-    in_container sh -c "cd ${chromiumos_remote_tmp_dir} && tar -cJ kernel" \
-		 > "${commit_archive}"
-    result=$?
-    if [[ $result != 0 ]] ; then
-	rm -f "${commit_archive}"
-	return $result
+    if $chromiumos_save_kernel_builds ; then
+        in_container sh -c "cd ${chromiumos_remote_tmp_dir} && tar -cJ kernel" \
+                     > "${commit_archive}"
+        result=$?
+        if [[ $result != 0 ]] ; then
+            rm -f "${commit_archive}"
+            return $result
+        fi
     fi
 
     default_build_func "${container_tmpdir}" "${headers_dir}" "${make_args}"

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -36,17 +36,10 @@ pkg_files_to_dependencies_chromiumos() { true ; }
 
 install_pkgs_dir_chromiumos()
 {
-    install_pkgs genisoimage squashfs-tools
     in_container sh -c "
 	set -x ;
-	rm -rf $chromiumos_remote_tmp_dir/squashfs-root ;
-	mkdir -p $chromiumos_remote_tmp_dir &&
-	for iso_file in $1/* ; do
-		isoinfo -J -R -x /chromiumos/cpio.gz -i \$iso_file |
-			gunzip |
-			( cd $chromiumos_remote_tmp_dir && cpio --extract usr.squashfs ) &&
-		( cd $chromiumos_remote_tmp_dir && unsquashfs usr.squashfs lib lib64/modules ) ;
-	done"
+	rm -rf $chromiumos_remote_tmp_dir
+	mv $1/*/. $chromiumos_remote_tmp_dir"
 }
 
 get_dist_releases_chromiumos()

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -111,10 +111,9 @@ chromiumos_build() {
          cd ${container_tmpdir}/pxfuse_dir &&
 	 make clean" || return $?
 
-    default_build_func "${container_tmpdir}" "${headers_dir}" "${make_args}" ||
-	return $?
-
-    mkdir -p "${commit_tgz%/*}"
+    mkdir -p "${commit_tgz%/*}" &&
     in_container sh -c "cd ${container_tmpdir} && tar cz kernel" \
-		 > "${commit_tgz}"
+		 > "${commit_tgz}" &&
+
+    default_build_func "${container_tmpdir}" "${headers_dir}" "${make_args}"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.chromiumos.sh
@@ -56,22 +56,65 @@ dist_clean_up_container_chromiumos()
     dist_clean_up_container_ubuntu   "$@"
 }
 
-chromiumos_prepare_build() {
+chromiumos_build() {
     local container_tmpdir="$1"
-    local branch="$3"
+    local headers_dir="$2"
+    local make_args="$3"
+    local log_subdir="$4"
+    local branch="$5"
+    local commit_name=${log_subdir##*/}
+    local commit_tgz="/home/ftp/cache/kernels/chromiumos/${commit_name}.tar.gz"
+    local build_dir
+
+    # Currently, px.ko does not depend on any other kernel modules, so
+    # we could probably skip making the kernel modules.  If you want to try
+    # this optimization, set the variable make_modules_command to "true" (a
+    # no-op) instead of "make modules":
+    #
+    # local make_modules_command="true"
+    local make_modules_command="make modules"
 
     install_pkgs curl
     # FIXME?  Is it necessory to "apt-get install" some other packages,
     # besides curl?
 
-    in_container sh -c \
+    if [[ -e "${commit_tgz}" ]] ; then
+	in_container sh -c \
+            "rm -rf ${container_tmpdir}/kernel &&
+             cd ${container_tmpdir} &&
+	     tar xpz kernel" < "${commit_tgz}" || return $?
+	headers_dir="${container_tmpdir}/kernel"
+    else
+	in_container sh -c \
                "cd ${chromiumos_remote_tmp_dir} &&
 		git clean --force &&
 		git checkout ${branch} &&
 		./chromeos/scripts/prepareconfig chromiumos-x86_64 &&
 		make prepare &&
-		make scripts"
-    # 		make &&
-    #		make modules
-    # "make && make modules" is for kernel symbol versioning.
+		make scripts" || return $?
+    fi
+
+    default_build_func "${container_tmpdir}" "${headers_dir}" "${make_args}" ||
+	return $?
+
+    if [[ -e "${commit_tgz}" ]] ; then
+	return 0
+    fi
+
+    # Build the whole kernel (and possibly modules, depending on the
+    # value of ${make_modules_command}), just to have kernel symbol
+    # versioning information against which px.ko.
+    in_container sh -c \
+        "cd ${container_tmpdir}/kernel &&
+	 make vmlinux &&
+	 ${make_modules_command} &&
+         cd ${container_tmpdir}/pxfuse_dir &&
+	 make clean" || return $?
+
+    default_build_func "${container_tmpdir}" "${headers_dir}" "${make_args}" ||
+	return $?
+
+    mkdir -p "${commit_tgz%/*}"
+    in_container sh -c "cd ${container_tmpdir} && tar cz kernel" \
+		 > "${commit_tgz}"
 }

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -22,7 +22,7 @@ in_container_flock_deb() {
     # acquire (and release) the dpkg lock, to reduce the chance of the
     # command failing due to some automatic dpkg database update running
     # or something like that.  Something taking the lock broke a few
-    # of he Ubuntu rebuild tests.
+    # of the Ubuntu rebuild tests.
     local seconds=600
     local lockfile=/var/lib/dpkg/lock
     in_container env DEBIAN_FRONTEND=noninteractive \

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -37,7 +37,7 @@ deb_in_container_apt_get() {
 
 dist_start_container_deb()
 {
-    local cmd="apt-get install --quiet --quiet --yes"
+    local cmd="apt-get --quiet --quiet --yes"
     local new_args="--allow-downgrades --allow-remove-essential --allow-change-held-packages"
 
     if in_container_flock_deb sh -c "$cmd $new_args install bash 2> /dev/null" ; then

--- a/pwx_test_kernel_pkgs/distro_driver.deb.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.deb.sh
@@ -19,7 +19,7 @@ deb_apt_get_cmd="apt-get --quiet --quiet --yes --force-yes"
 
 in_container_flock_deb() {
     # Do an in_container command, but block for up to five minutes to
-    # acquire (and release) the dpkg lock, to reduce the change of the
+    # acquire (and release) the dpkg lock, to reduce the chance of the
     # command failing due to some automatic dpkg database update running
     # or something like that.  Something taking the lock broke a few
     # of he Ubuntu rebuild tests.

--- a/pwx_test_kernel_pkgs/distro_driver.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.sh
@@ -7,6 +7,7 @@
 . $scriptsdir/distro_driver.debian.sh
 . $scriptsdir/distro_driver.ubuntu.sh
 . $scriptsdir/distro_driver.centos.sh
+. $scriptsdir/distro_driver.chromiumos.sh
 . $scriptsdir/distro_driver.coreos.sh
 . $scriptsdir/distro_driver.fedora.sh
 . $scriptsdir/distro_driver.opensuse.sh

--- a/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
+++ b/pwx_test_kernel_pkgs/distro_driver.ubuntu.sh
@@ -3,7 +3,6 @@
 
 # For now, just default everything to the common Debian drivers.
 
-dist_init_container_ubuntu()      { dist_init_container_deb       "$@" ; }
 pkg_files_to_kernel_dirs_ubuntu() { pkg_files_to_kernel_dirs_deb  "$@" ; }
 pkg_files_to_dependencies_ubuntu() { pkg_files_to_dependencies_deb "$@" ; }
 pkg_files_to_names_ubuntu()       { pkg_files_to_names_deb        "$@" ; }
@@ -14,6 +13,12 @@ pkgs_update_ubuntu()              { pkgs_update_deb               "$@" ; }
 dist_clean_up_container_ubuntu()  { dist_clean_up_container_deb   "$@" ; }
 dist_start_container_ubuntu()     { dist_start_container_deb      "$@"; }
 start_container_ubuntu()          { start_container_generic "$@" ; }
+
+dist_init_container_ubuntu() {
+    dist_init_container_deb       "$@"
+    install_pkgs bc	# Not needed for Ubuntu, but ChromiumOS wants it.
+}
+
 
 get_dist_releases_ubuntu()
 {

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -10,6 +10,7 @@ Usage: pwx_test_kernel_pkgs [options] pkg_files...
 	--all-releases
 	--arch=architecture            [default: amd64]
 	--containers=container_system  [default: docker]
+	--container-tmpdir=dir       [default: /tmp/test-portworx-kernels.\$\$]
 	--distribution=dist            [default: ubuntu]
 	--force
         --help
@@ -47,11 +48,14 @@ exit_handler() {
 
 # Use a function to parse main argument to avoid modifying them.
 parse_args() {
+    local all_args="$*"
+    local non_switch_args=0
     while [[ $# -gt 0 ]] ; do
 	case "$1" in
 	    --all-releases ) all_releases=true ;;
 	    --arch=* ) arch=${1#--arch=} ;;
 	    --containers=* ) container_system=${1#--containers=} ;;
+	    --container-tmpdir=* ) extra_args="$extra_args $1" ;;
 	    --distribution=* ) distro=${1#--distribution=} ;;
 	    --force ) force=true ;;
 	    --help ) usage ; exit 0 ;;
@@ -63,13 +67,17 @@ parse_args() {
 	    --skip-build ) extra_args="$extra_args $1" ; skip_build=true ;;
 	    --skip-cleanup ) extra_args="$extra_args $1" ;;
 	    --skip-load ) extra_args="$extra_args $1" ;;
-	    --* ) usage >&2 ; exit 1 ;;
-	    * ) break ;;
+	    -- ) break ;;
+	    --* )
+		echo "pwx_test_kernel_pkgs: Unrecognized option \"${1}\"." >&2
+		usage >&2
+		exit 1 ;;
+	    * ) non_switch_args=$(($non_switch_args + 1)) ;;
 	esac
 	shift
     done
 
-    if [[ $# -lt 1 ]] ; then
+    if [[ $non_switch_args -lt 1 ]] ; then
 	usage >&2
 	exit 1
     fi
@@ -134,8 +142,6 @@ matches_first() {
 
 test_kernel_pkgs() {
     local result release releases local make_args lockfile
-
-    echo "Command: test_kernel_pkgs $*"
 
     if [[ -n "$distro_releases" ]] ; then
 	releases=$(echo "$distro_releases" | sed 's/,/ /g')

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -39,6 +39,7 @@ force=false
 logdir=$PWD
 lockdir=/var/lock/pwx_test_kernel_pkgs
 pxfuse_dir=
+skip_build=false
 
 exit_handler() {
     rm -rf "$local_tmp_dir"
@@ -59,7 +60,7 @@ parse_args() {
 	    --pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
 	    --prepare-build ) extra_args="$extra_args $1" ;;
 	    --releases=* ) distro_release=${1#--releases=} ;;
-	    --skip-build ) extra_args="$extra_args $1" ;;
+	    --skip-build ) extra_args="$extra_args $1" ; skip_build=true ;;
 	    --skip-cleanup ) extra_args="$extra_args $1" ;;
 	    --skip-load ) extra_args="$extra_args $1" ;;
 	    --* ) usage >&2 ; exit 1 ;;
@@ -134,7 +135,7 @@ matches_first() {
 test_kernel_pkgs() {
     local result release releases local make_args lockfile
 
-    echo "Command: pwx_test_kernel_pkgs $*"
+    echo "Command: test_kernel_pkgs $*"
 
     if [[ -n "$distro_releases" ]] ; then
 	releases=$(echo "$distro_releases" | sed 's/,/ /g')
@@ -174,8 +175,10 @@ test_kernel_pkgs() {
 	    break
 	fi
     done
-    echo "$result $distro $release make_args=$make_args" > "$logdir/exit_code"
-    mv "$logdir/ran_test" "$logdir/done" 2> /dev/null
+    if ! $skip_build ; then
+	echo "$result $distro $release make_args=$make_args" > "$logdir/exit_code"
+	mv "$logdir/ran_test" "$logdir/done" 2> /dev/null
+    fi
     return $result
 }
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs
@@ -7,6 +7,7 @@ usage() {
     cat <<EOF
 Usage: pwx_test_kernel_pkgs [options] pkg_files...
     options:
+	--all-releases
 	--arch=architecture            [default: amd64]
 	--containers=container_system  [default: docker]
 	--distribution=dist            [default: ubuntu]
@@ -16,7 +17,11 @@ Usage: pwx_test_kernel_pkgs [options] pkg_files...
 	--logdir=logdir                [default: based on distribution]
 	--pfxuse=pxfuse_src_dir        [default: download tempoary
 				        directory from github]
+	--prepare-build
 	--releases=dist_releases       [default: based on distribution]
+	--skip-build
+	--skip-cleanup
+	--skip-load
 EOF
 }
 
@@ -24,9 +29,11 @@ EOF
 . ${scriptsdir}/container_driver.sh
 . ${scriptsdir}/distro_driver.sh
 
+all_releases=false
 arch=amd64
 distro=ubuntu
 distro_releases=""
+extra_args=""
 container_system=lxc
 force=false
 logdir=$PWD
@@ -41,6 +48,7 @@ exit_handler() {
 parse_args() {
     while [[ $# -gt 0 ]] ; do
 	case "$1" in
+	    --all-releases ) all_releases=true ;;
 	    --arch=* ) arch=${1#--arch=} ;;
 	    --containers=* ) container_system=${1#--containers=} ;;
 	    --distribution=* ) distro=${1#--distribution=} ;;
@@ -49,7 +57,11 @@ parse_args() {
 	    --leave-containers-running ) true ;;
 	    --logdir=* ) logdir=${1#--logdir=} ;;
 	    --pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
+	    --prepare-build ) extra_args="$extra_args $1" ;;
 	    --releases=* ) distro_release=${1#--releases=} ;;
+	    --skip-build ) extra_args="$extra_args $1" ;;
+	    --skip-cleanup ) extra_args="$extra_args $1" ;;
+	    --skip-load ) extra_args="$extra_args $1" ;;
 	    --* ) usage >&2 ; exit 1 ;;
 	    * ) break ;;
 	esac
@@ -149,7 +161,8 @@ test_kernel_pkgs() {
 			"--pxfuse=$pxfuse_dir" \
 			"--release=$release" \
 			"--make-args=$make_args" \
-			$@
+			$extra_args \
+			"$@"
 
 	    result=$?
 
@@ -157,7 +170,7 @@ test_kernel_pkgs() {
 		break
 	    fi
 	done
-	if [[ $result = 0 ]] ; then
+	if [[ $result = 0 ]] && ! $all_releases ; then
 	    break
 	fi
     done

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -41,9 +41,9 @@ force=false
 logdir=$PWD
 pxfuse_dir=""
 prepare_build=false
-skip_build=true
-skip_cleanup=true
-skip_load=true
+skip_build=false
+skip_cleanup=false
+skip_load=false
 
 exit_handler() {
     rm -rf "$local_tmp_dir"
@@ -295,8 +295,8 @@ test_kernel_pkgs_func() {
     make_args="$3"
     shift 3
 
-    if ! $skip_download ; then
-	test_kernel_pkgs_download "$pxfuse_dir" "$@" || return $?
+    if ! $skip_load ; then
+	test_kernel_pkgs_load "$pxfuse_dir" "$@" || return $?
     fi
 
     if ! $skip_build ; then

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -108,6 +108,24 @@ filter_word() {
     echo "$first"
 }
 
+guess_utsname_from_headers_dir() {
+    local headers_dir="$1"
+    local guess_utsname
+
+    guess_utsname=${headers_dir#/usr/src/}
+    guess_utsname=${guess_utsname#kernels/}
+    guess_utsname=${guess_utsname#linux-headers-}
+
+    case "$guess_utsname" in
+	/tmp/coreos_remote_tmp_dir/* )
+	    guess_utsname=${guess_utsname#/tmp/coreos_remote_tmp_dir/squashfs-root/lib/modules/}
+	    guess_utsname=${guess_utsname%/}
+	    guess_utsname=${guess_utsname%/build}
+		    ;;
+    esac
+}
+
+
 test_kernel_pkgs_func() {
     local container_tmpdir result_logdir
     local result filename real dirname basename headers_dir
@@ -191,17 +209,7 @@ test_kernel_pkgs_func() {
 	    in_container tar -C "${container_tmpdir}/pxfuse_dir" -c px.ko |
 		tar -C "${result_logdir}" -xpv
 
-	    guess_utsname=${headers_dir#/usr/src/}
-	    guess_utsname=${guess_utsname#kernels/}
-	    guess_utsname=${guess_utsname#linux-headers-}
-
-	    case "$guess_utsname" in
-		/tmp/coreos_remote_tmp_dir/* )
-		    guess_utsname=${guess_utsname#/tmp/coreos_remote_tmp_dir/squashfs-root/lib/modules/}
-		    guess_utsname=${guess_utsname%/}
-		    guess_utsname=${guess_utsname%/build}
-		    ;;
-	    esac
+	    guess_utsname=$(guess_utsname_from_headers_dir "$headers_dir")
 
 	    pxd_version=$(set -- $(egrep '^#define PXD_VERSION ' < "${pxfuse_dir}/pxd.h") ; echo $3)
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -287,7 +287,7 @@ test_kernel_pkgs_build() {
         rm -rf "$export_pkgs_dir" "$export_module_dir"
         mkdir -p "$export_pkgs_dir" "$export_module_dir"
         ln --symbolic --force "$@" "${export_pkgs_dir}/"
-        symlinks -c "$export_pkgs_dir" > /dev/null
+        symlinks -c -d "$export_pkgs_dir" > /dev/null
 
         cp "${result_logdir}/px.ko" "${export_module_dir}/"
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -130,6 +130,7 @@ test_kernel_pkgs_func() {
     local container_tmpdir result_logdir
     local result filename real dirname basename headers_dir
     local pkg_names deps_unfiltered dep_names arg guess_utsname
+    local dep_filtered
     local export_dir export_pkgs_dir export_module_dir
     local container_tmpdir=/tmp/test-portworx-kernels.$$
     local pxfuse_dir pxd_version
@@ -165,7 +166,8 @@ test_kernel_pkgs_func() {
 
     dep_names=""
     for dep in $deps_unfiltered ; do
-	dep_names="$dep_names $(filter_word "$dep" $pkg_names)"
+	dep_filtered=$(filter_word "$dep" $pkg_names)
+	dep_names="$dep_names $dep_filtered"
     done
 
     install_pkgs $dep_names

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -251,7 +251,7 @@ test_kernel_pkgs_build() {
     # never happen.
 
     if [[ -z "$headers_dir" ]] ; then
-        echo "FATAL: test_kernel_pkgs_func: null \$headers_dir, \$* = $*." >&2
+        echo "FATAL: test_kernel_pkgs_build: null \$headers_dir, \$* = $*." >&2
         return 1
     fi
 

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -143,10 +143,6 @@ guess_utsname_from_headers_dir() {
     esac
 }
 
-load_container() {
-}
-
-
 # Usage: test_kernel_pkgs_load pxfuse_dir files...
 test_kernel_pkgs_load() {
     local container_tmpdir

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -125,7 +125,6 @@ guess_utsname_from_headers_dir() {
     esac
 }
 
-
 test_kernel_pkgs_func() {
     local container_tmpdir result_logdir
     local result filename real dirname basename headers_dir

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -52,18 +52,11 @@ exit_handler() {
 
 echo "" >&2
 echo "Command: pwx_test_kernel_pkgs_one_container.sh $*" >&2
-echo "pwx_test_kernel_pkgs_one_container \$1=$1." >&2
-echo "pwx_test_kernel_pkgs_one_container \$2=$2." >&2
-echo "pwx_test_kernel_pkgs_one_container \$3=$3." >&2
-echo "pwx_test_kernel_pkgs_one_container \$4=$4." >&2
-echo "pwx_test_kernel_pkgs_one_container \$5=$5." >&2
 
 i=1
 count=1
 while [[ $i -le $# ]] ; do
     arg="${@:$i:1}"
-    echo "AJR pwx_test_kernel_pkgs_on_container.sh arg $count = $arg." >&2
-    count=$((count + 1))
     case "$arg" in
 	--all-releases ) true ;; # Ignore
 	--arch=* ) arch=${arg#--arch=} ;;

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -14,11 +14,15 @@ Usage: pwx_test_kernel_pkgs [options] pkg_files...
         --help
 	--leave-containers-running
 	--logdir=logdir                [default: based on distribution]
+	--prepare-build
 	--pfxuse=pxfuse_src_dir        [default: download tempoary
 				        directory from github]
 	--release=dist_releaes         Which releaes of the OS distribution
                                        to use.  Mandatory.
 	--releases=dist_releases       Ignored
+	--skip-build
+	--skip-cleanup
+	--skip-load
 EOF
 }
 
@@ -36,6 +40,10 @@ make_args=""
 force=false
 logdir=$PWD
 pxfuse_dir=""
+prepare_build=false
+skip_build=true
+skip_cleanup=true
+skip_load=true
 
 exit_handler() {
     rm -rf "$local_tmp_dir"
@@ -57,6 +65,10 @@ while [[ $# -gt 0 ]] ; do
 	--pxfuse=* ) pxfuse_dir=${1#--pxfuse=} ;;
 	--release=* ) distro_release=${1#--release=} ;;
 	--releases=* ) true ;;	# Ignore
+	--prepare-build ) prepare_build=true ;;
+	--skip-build ) skip_build=true ;;
+	--skip-cleanup ) skip_cleanup=true ;;
+	--skip-load ) skip_load=true ;;
 	--* ) usage >&2 ; exit 1 ;;
 	* ) break ;;
     esac
@@ -112,6 +124,12 @@ guess_utsname_from_headers_dir() {
     local headers_dir="$1"
     local guess_utsname
 
+    guess_utsname=$(in_container cat "${headers_dir}/include/config/kernel.release")
+    if [[ $? = 0 ]] && [[ -n "$guess_utsname" ]] ; then
+	echo "${guess_utsname}"
+	return 0
+    fi
+
     guess_utsname=${headers_dir#/usr/src/}
     guess_utsname=${guess_utsname#kernels/}
     guess_utsname=${guess_utsname#linux-headers-}
@@ -125,26 +143,20 @@ guess_utsname_from_headers_dir() {
     esac
 }
 
-test_kernel_pkgs_func() {
-    local container_tmpdir result_logdir
-    local result filename real dirname basename headers_dir
-    local pkg_names deps_unfiltered dep_names arg guess_utsname
-    local dep_filtered
-    local export_dir export_pkgs_dir export_module_dir
-    local container_tmpdir=/tmp/test-portworx-kernels.$$
-    local pxfuse_dir pxd_version
-    local make_args=
+load_container() {
+}
 
-    for arg in "$@" ; do
-	echo "    $arg"
-    done >&2
-    echo "(end of arguments)" >&2
-    echo "" >&2
+
+# Usage: test_kernel_pkgs_load pxfuse_dir files...
+test_kernel_pkgs_load() {
+    local container_tmpdir
+    local result filename real dirname basename headers_dir
+    local pkg_names deps_unfiltered dep_names dep_filtered
+    local container_tmpdir=/tmp/test-portworx-kernels.$$
+    local pxfuse_dir
 
     pxfuse_dir="$1"
-    result_logdir="$2"
-    make_args="$3"
-    shift 3
+    shift
 
     in_container rm -rf "$container_tmpdir"
     in_container mkdir -p "$container_tmpdir/pxfuse_dir" "$container_tmpdir/header_pkgs"
@@ -178,8 +190,34 @@ test_kernel_pkgs_func() {
     if [[ $result != 0 ]] ; then
 	uninstall_pkgs $pkg_names
 	in_container rm -rf "$container_tmpdir"
-	return $result
     fi
+
+    return $result
+}
+
+test_kernel_pkgs_build() {
+    local container_tmpdir result_logdir
+    local result headers_dir
+    local pkg_names deps_unfiltered dep_names guess_utsname
+    local dep_filtered
+    local export_dir export_pkgs_dir export_module_dir
+    local container_tmpdir=/tmp/test-portworx-kernels.$$
+    local pxfuse_dir pxd_version
+    local make_args=
+
+    pxfuse_dir="$1"
+    result_logdir="$2"
+    make_args="$3"
+    shift 3
+
+    pkg_names=$(pkg_files_to_names "$@")
+    deps_unfiltered=$(pkg_files_to_dependencies "$@")
+
+    dep_names=""
+    for dep in $deps_unfiltered ; do
+	dep_filtered=$(filter_word "$dep" $pkg_names)
+	dep_names="$dep_names $dep_filtered"
+    done
 
     headers_dir=$(pkg_files_to_kernel_dirs "$@" | sort -u | tail -1)
     # Use "tail" to get the last kernel directory that is alphabetically
@@ -197,14 +235,23 @@ test_kernel_pkgs_func() {
         return 1
     fi
 
-    in_container sh -c \
+    result=0
+    if $prepare_build ; then 
+	${distro}_prepare_build "${container_tmpdir}" "$@"
+	result=$?
+    fi
+    if [[ $result = 0 ]] ; then
+	in_container sh -c \
                  "cd ${container_tmpdir}/pxfuse_dir && \
                   autoreconf && \
                   ./configure && \
                   make KERNELPATH=$headers_dir $make_args"
-    # make KERNELPATH=$headers_dir CC=\"gcc -fno-pie\"
 
-    result=$?
+	# make KERNELPATH=$headers_dir CC=\"gcc -fno-pie\"
+
+	result=$?
+    fi
+    
     if [[ "$result" = 0 ]] ; then
         in_container tar -C "${container_tmpdir}/pxfuse_dir" -c px.ko |
             tar -C "${result_logdir}" -xpv
@@ -225,11 +272,49 @@ test_kernel_pkgs_func() {
         cp "${result_logdir}/px.ko" "${export_module_dir}/"
 
     fi # result = 0
+
     touch "${result_logdir}/ran_test"
 
-    uninstall_pkgs $pkg_names
-    in_container rm -rf "$container_tmpdir"
-    dist_clean_up_container
+    return $result
+}
+
+test_kernel_pkgs_func() {
+    local container_tmpdir result_logdir
+    local result filename headers_dir
+    local pkg_names deps_unfiltered dep_names arg guess_utsname
+    local dep_filtered
+    local export_dir export_pkgs_dir export_module_dir
+    local container_tmpdir=/tmp/test-portworx-kernels.$$
+    local pxfuse_dir pxd_version
+    local make_args=
+
+    for arg in "$@" ; do
+	echo "    $arg"
+    done >&2
+    echo "(end of arguments)" >&2
+    echo "" >&2
+
+    pxfuse_dir="$1"
+    result_logdir="$2"
+    make_args="$3"
+    shift 3
+
+    if ! $skip_download ; then
+	test_kernel_pkgs_download "$pxfuse_dir" "$@" || return $?
+    fi
+
+    if ! $skip_build ; then
+	test_kernel_pkgs_build \
+	    "$pxfuse_dir" "$result_logdir" "$make_args" "$@"
+	result=$?
+    fi
+
+    if ! $skip_cleanup ; then
+	pkg_names=$(pkg_files_to_names "$@")
+	uninstall_pkgs $pkg_names
+	in_container rm -rf "$container_tmpdir"
+	dist_clean_up_container
+    fi
 
     echo "test_kernel_pkgs_func: build_exit_code=$result" >&2
     # if [[ "$result" != 0 ]] ; then

--- a/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
+++ b/pwx_test_kernel_pkgs/pwx_test_kernel_pkgs_one_container.sh
@@ -165,7 +165,7 @@ test_kernel_pkgs_load() {
 	dirname=${real%/*}
 	basename=${real##*/}
 	tar -C "$dirname" -c -- "$basename" |
-	    in_container tar -C "${container_tmpdir}/header_pkgs" -xpv
+	    in_container tar -C "${container_tmpdir}/header_pkgs" -xp
     done
 
     pkg_names=$(pkg_files_to_names "$@")

--- a/pwx_test_kernel_pkgs/unused/distro_driver.coreos.sh.use_devel_image
+++ b/pwx_test_kernel_pkgs/unused/distro_driver.coreos.sh.use_devel_image
@@ -1,0 +1,86 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+# For now, just default everything to the common RPM drivers.
+
+coreos_remote_tmp_dir=/tmp/coreos_remote_tmp_dir
+
+pkg_files_to_names_coreos()       { pkg_files_to_names_rpm        "$@" ; }
+pkg_files_to_dependencies_coreos() { pkg_files_to_dependencies_rpm "$@" ; }
+install_pkgs_coreos()             { install_pkgs_rpm              "$@" ; }
+install_pkgs_dir_coreos()         { install_pkgs_dir_rpm          "$@" ; }
+uninstall_pkgs_coreos()           { uninstall_pkgs_rpm            "$@" ; }
+pkgs_update_coreos()              { pkgs_update_rpm               "$@" ; }
+dist_start_container_coreos()     { dist_start_container_rpm      "$@" ; }
+
+start_container_coreos()
+{
+    # lxc-create does not provide a CoreOS template, so build
+    # under CentOS for now.
+
+    start_container_generic --template=none -- "$@"
+}
+
+dist_init_container_coreos() { dist_init_container_rpm "$@" ; }
+
+install_pkgs_coreos()             { install_pkgs_rpm              "$@" ; }
+install_pkgs_dir_coreos()         { install_pkgs_dir_rpm          "$@" ; }
+uninstall_pkgs_coreos()           { uninstall_pkgs_rpm            "$@" ; }
+
+# Rely on dist_clean_up_container_coreos to remove the CoreOS
+# .iso files that were installed by install_pkgs_dir_coreos.  So,
+# pkg_files_to_names_coreos and pkg_files_to_dependencies_coreoss
+# do not output the names of any packages to remove or install.
+pkg_files_to_names_coreos()        { true ; }
+pkg_files_to_dependencies_coreos() { true ; }
+
+coreos_unpack_image()
+{
+    local bz2="$1"
+    local disk_image=/tmp/disk_image	# FIXME
+    local partition_image=/tmp/partition_image	# FIXME
+    local mount_point=/mnt
+    local start_sec
+
+    bunzip2 < "$bz2" > "$disk_image"
+    set $(sgdisk --print "$disk_image" | egrep '^[[:space:]]+[0-9]' | head -1)
+    start_sec=$2
+    mkdir -p "$mount_point"
+    mount -o loop,offset=$((start_sec * 512)) -t btrfs \
+	  "$partition" "$mount_point"
+    lxc-create -t none --name my_coreos2 --dir "$mount_point"
+}
+
+install_pkgs_dir_coreos()
+{
+    install_pkgs genisoimage squashfs-tools
+    in_container sh -c "
+	set -x ;
+	rm -rf $coreos_remote_tmp_dir/squashfs-root ;
+	mkdir -p $coreos_remote_tmp_dir &&
+	for iso_file in $1/* ; do
+		isoinfo -J -R -x /coreos/cpio.gz -i \$iso_file |
+			gunzip |
+			( cd $coreos_remote_tmp_dir && cpio --extract usr.squashfs ) &&
+		( cd $coreos_remote_tmp_dir && unsquashfs usr.squashfs lib lib64/modules ) ;
+	done"
+}
+
+get_dist_releases_coreos()
+{
+    # For now, build from the latest Centos release only.  CoreOS
+    # does not include gcc by default.
+    set -- $(get_dist_releases_centos "$@")
+    echo "$1"
+}
+
+pkg_files_to_kernel_dirs_coreos()
+{
+    in_container sh -c "echo $coreos_remote_tmp_dir/squashfs-root/lib/modules/[0-9]*/build"
+}
+
+dist_clean_up_container_coreos()
+{
+    in_container rm -rf "$coreos_remote_tmp_dir"
+    dist_clean_up_container_rpm   "$@"
+}

--- a/pwx_test_kernels_in_mirror/install.sh
+++ b/pwx_test_kernels_in_mirror/install.sh
@@ -59,7 +59,7 @@ chmod a+x \
 #
 # install_crontab
 
-for dist in centos coreos debian fedora opensuse ubuntu ; do
+for dist in centos chromiumos coreos debian fedora opensuse ubuntu ; do
     mkdir -p "${downloads_dir}/${dist}"
 done
 

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -1,0 +1,28 @@
+# This is not a standalone program.  It is a library to be sourced by a shell
+# script.
+
+pkg_files_to_names_chromiumos()       { true ; }
+
+get_default_mirror_dirs_chromiumos()
+{
+    echo /home/ftp/mirrors/git/https/chromium.googlesource.com/thirdparty/kernel
+}
+
+walk_mirror_chromiumos() {
+    local mirror_tree="$1"
+    local return_status=0
+    local branch
+
+    shift 1
+
+    "$@" --skip-build --skip-cleanup --all-containers "$mirror_tree"
+    ( cd "$mirror_tree" && git brach -a ) |
+	while read branch ; do
+            if ! "$@" --skip-load --prepare-build --skip-cleanup "$mirror_tree/$branch" "$branch" ; then
+		return_status=$?
+	    fi
+	done
+    "$@" --skip-load --skip-build --all-containers "$mirror_tree"
+
+    return $return_status
+}

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -17,6 +17,7 @@ walk_mirror_chromiumos() {
 
     "$@" --skip-build --skip-cleanup --all-releases "$mirror_tree"
     ( cd "$mirror_tree" && git branch -a ) |
+	awk '{print $NF;}' |
 	while read branch ; do
             if ! "$@" --skip-load --prepare-build --skip-cleanup "$mirror_tree/$branch" "$branch" ; then
 		return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -12,18 +12,25 @@ walk_mirror_chromiumos() {
     local mirror_tree="$1"
     local return_status=0
     local branch
+    local container_tmpdir=/tmp/test-portworx-kernels.$$
 
     shift 1
 
-    "$@" --skip-build --skip-cleanup --all-releases "$mirror_tree"
+    "$@" --skip-build --skip-cleanup --all-releases \
+	 "--container-tmpdir=${container_tmpdir}" "$mirror_tree"
+
     ( cd "$mirror_tree" && git branch -a ) |
 	awk '{print $NF;}' |
 	while read branch ; do
-            if ! "$@" --skip-load --prepare-build --skip-cleanup "$mirror_tree/$branch" "$branch" ; then
+            if ! "$@" --skip-load --prepare-build --skip-cleanup \
+		 "--container-tmpdir=${container_tmpdir}" \
+		 "$mirror_tree/$branch" "$branch" ; then
 		return_status=$?
 	    fi
 	done
-    "$@" --skip-load --skip-build --all-releases "$mirror_tree"
+
+    "$@" --skip-load --skip-build --all-releases \
+	 "--container-tmpdir=${container_tmpdir}" "$mirror_tree"
 
     return $return_status
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -16,7 +16,7 @@ walk_mirror_chromiumos() {
     shift 1
 
     "$@" --skip-build --skip-cleanup --all-containers "$mirror_tree"
-    ( cd "$mirror_tree" && git brach -a ) |
+    ( cd "$mirror_tree" && git branch -a ) |
 	while read branch ; do
             if ! "$@" --skip-load --prepare-build --skip-cleanup "$mirror_tree/$branch" "$branch" ; then
 		return_status=$?

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -5,7 +5,7 @@ pkg_files_to_names_chromiumos()       { true ; }
 
 get_default_mirror_dirs_chromiumos()
 {
-    echo /home/ftp/mirrors/git/https/chromium.googlesource.com/thirdparty/kernel
+    echo /home/ftp/mirrors/git/https/chromium.googlesource.com/chromiumos/third_party/kernel
 }
 
 walk_mirror_chromiumos() {
@@ -15,14 +15,14 @@ walk_mirror_chromiumos() {
 
     shift 1
 
-    "$@" --skip-build --skip-cleanup --all-containers "$mirror_tree"
+    "$@" --skip-build --skip-cleanup --all-releases "$mirror_tree"
     ( cd "$mirror_tree" && git branch -a ) |
 	while read branch ; do
             if ! "$@" --skip-load --prepare-build --skip-cleanup "$mirror_tree/$branch" "$branch" ; then
 		return_status=$?
 	    fi
 	done
-    "$@" --skip-load --skip-build --all-containers "$mirror_tree"
+    "$@" --skip-load --skip-build --all-releases "$mirror_tree"
 
     return $return_status
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -22,7 +22,7 @@ walk_mirror_chromiumos() {
     ( cd "$mirror_tree" && git branch -a ) |
 	awk '{print $NF;}' |
 	while read branch ; do
-	    last_commit=$(cd "$mirror_tree" && git log --max-count=1 ..remotes/origin/0.12.362.B | ( read commit id ; echo "$id" ) )
+	    last_commit=$(cd "$mirror_tree" && git rev-list --max-count=1 "$branch" )
 	    echo "AJR walk_mirror_chromiumos: branch=${branch} last_commit=${last_commit}." >&2
             if ! "$@" --skip-load --prepare-build --skip-cleanup \
 		 "--container-tmpdir=${container_tmpdir}" \

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.chromiumos.sh
@@ -11,7 +11,7 @@ get_default_mirror_dirs_chromiumos()
 walk_mirror_chromiumos() {
     local mirror_tree="$1"
     local return_status=0
-    local branch
+    local branch last_commit
     local container_tmpdir=/tmp/test-portworx-kernels.$$
 
     shift 1
@@ -22,9 +22,11 @@ walk_mirror_chromiumos() {
     ( cd "$mirror_tree" && git branch -a ) |
 	awk '{print $NF;}' |
 	while read branch ; do
+	    last_commit=$(cd "$mirror_tree" && git log --max-count=1 ..remotes/origin/0.12.362.B | ( read commit id ; echo "$id" ) )
+	    echo "AJR walk_mirror_chromiumos: branch=${branch} last_commit=${last_commit}." >&2
             if ! "$@" --skip-load --prepare-build --skip-cleanup \
 		 "--container-tmpdir=${container_tmpdir}" \
-		 "$mirror_tree/$branch" "$branch" ; then
+		 "$mirror_tree/${branch}/commit-${last_commit}" "$branch" ; then
 		return_status=$?
 	    fi
 	done

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.coreos.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.coreos.sh
@@ -30,5 +30,13 @@ walk_mirror_coreos() {
 	    fi
 	done
 
+    #find "$mirror_tree" -name 'coreos_developer_container.bin.bz2' -type f \
+    #     -print0 |
+    #    while read -r -d $'\0' file ; do
+    #        if ! "$@" "$file" ; then
+    #            return_status=$?
+    #        fi
+    #    done
+
     return $return_status
 }

--- a/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
+++ b/pwx_test_kernels_in_mirror/mirror_walk_driver.sh
@@ -7,6 +7,7 @@
 . $scriptsdir/mirror_walk_driver.debian.sh
 . $scriptsdir/mirror_walk_driver.ubuntu.sh
 . $scriptsdir/mirror_walk_driver.centos.sh
+. $scriptsdir/mirror_walk_driver.chromiumos.sh
 . $scriptsdir/mirror_walk_driver.coreos.sh
 . $scriptsdir/mirror_walk_driver.fedora.sh
 . $scriptsdir/mirror_walk_driver.opensuse.sh

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels.cron_script.sh
@@ -16,7 +16,7 @@ stop_lxc_test_containers() {
 
 main() {
     local result=0
-    for dist in centos coreos debian fedora opensuse ubuntu ; do
+    for dist in centos chromiumos coreos debian fedora opensuse ubuntu ; do
 	if ! pwx_test_kernels_in_mirror --distribution="$dist" \
 	     --command-args="--leave-containers-running --containers=lxc" ; then
 	    result=$?

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
@@ -85,18 +85,28 @@ prepare_pxfuse_dir() {
 
 PATH=$PATH:/usr/local/bin
 
+find_first_non_switch_arg() {
+    local i arg
+
+    i=1
+    while [[ $i -le $# ]] ; do
+	arg="${@:$i:1}"
+	case "$arg" in
+	    --* ) ;;
+	    * ) echo "$arg" ; return 0 ;;
+	esac
+	i=$((i + 1))
+    done
+    return 1
+}
+
 mirror_callback() {
     local mirror_dir="$1"
     local log_subdir="$2"
-    local pkg1 pkg_subdir command_logdir result word
+    local pkg1 pkg_subdir command_logdir result word i
 
     shift 2
-    for pkg1 in "$@" ; do
-	case "$pkg1" in
-	    --* ) shift ; continue ;;
-	    * ) break ;;
-	esac
-    done
+    pkg1=$(find_first_non_switch_arg "$@")
 
     if [[ -n "$mirror_top" ]] ; then
 	pkg_subdir=${pkg1#$mirror_top}

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
@@ -100,10 +100,23 @@ find_first_non_switch_arg() {
     return 1
 }
 
+# In case you want to run only a few examples from each release (for quick
+# testing), you can uncomment the following varialbes and the lines in
+# mirror_callback() that use them:
+# callback_count=1
+# max_callback_count=5
+
 mirror_callback() {
     local mirror_dir="$1"
     local log_subdir="$2"
     local pkg1 pkg_subdir command_logdir result word i
+
+    # echo "mirror_callback: distro=${distro} callback_count=${callback_count}." >&2
+    # callback_count=$((callback_count + 1))
+    # if [[ $callback_count -gt $max_callback_count ]] ; then
+    #     echo "AJR mirror_callback: skipping because callback_count > max_callback_count." >&2
+    #     return 0
+    # fi
 
     shift 2
     pkg1=$(find_first_non_switch_arg "$@")

--- a/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
+++ b/pwx_test_kernels_in_mirror/pwx_test_kernels_in_mirror
@@ -88,8 +88,15 @@ PATH=$PATH:/usr/local/bin
 mirror_callback() {
     local mirror_dir="$1"
     local log_subdir="$2"
-    local pkg1="$3"
-    local pkg_subdir command_logdir result
+    local pkg1 pkg_subdir command_logdir result word
+
+    shift 2
+    for pkg1 in "$@" ; do
+	case "$pkg1" in
+	    --* ) shift ; continue ;;
+	    * ) break ;;
+	esac
+    done
 
     if [[ -n "$mirror_top" ]] ; then
 	pkg_subdir=${pkg1#$mirror_top}
@@ -103,8 +110,6 @@ mirror_callback() {
 	# packages found in /home/ftp/downloads/<distribution>/.
 	pkg_subdir="${pkg1#/home/ftp/}"
     fi
-
-    shift 2
 
     command_logdir="${log_subdir}/${pkg_subdir}"
     mkdir -p "$command_logdir"


### PR DESCRIPTION
Add mirroring and building of ChromiumOS kernels, currently attempting to buid the latest revisions of each branch at git://chromium.googlesource.com/chromiumos/third_party/kernel .

There are currently about 1400 branches, but only about 200 successfully build.  The failures appear to be for legitimate reasons, for example x86_64 flavour being undefined or some kernel configuration options not being mentioned in the kernel configuration for x86_64 saved on the latest commit of that branch.